### PR TITLE
Add MixerSplitter UnitOperation

### DIFF
--- a/src/libcadet/CMakeLists.txt
+++ b/src/libcadet/CMakeLists.txt
@@ -123,6 +123,7 @@ set(LIBCADET_SOURCES
 	${CMAKE_SOURCE_DIR}/src/libcadet/model/UnitOperationBase.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/model/InletModel.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/model/OutletModel.cpp
+    ${CMAKE_SOURCE_DIR}/src/libcadet/model/MixerSplitterModel.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/model/StirredTankModel.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/model/LumpedRateModelWithoutPores.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/model/LumpedRateModelWithPores.cpp

--- a/src/libcadet/ModelBuilderImpl.cpp
+++ b/src/libcadet/ModelBuilderImpl.cpp
@@ -29,6 +29,7 @@ namespace cadet
 	{
 		void registerInletModel(std::unordered_map<std::string, std::function<IUnitOperation*(UnitOpIdx)>>& models);
 		void registerOutletModel(std::unordered_map<std::string, std::function<IUnitOperation*(UnitOpIdx)>>& models);
+		void registerMixerSplitterModel(std::unordered_map<std::string, std::function<IUnitOperation*(UnitOpIdx)>>& models);
 
 		void registerGeneralRateModel(std::unordered_map<std::string, std::function<IUnitOperation*(UnitOpIdx)>>& models);
 		void registerLumpedRateModelWithPores(std::unordered_map<std::string, std::function<IUnitOperation*(UnitOpIdx)>>& models);
@@ -55,6 +56,7 @@ namespace cadet
 		// Register all available models
 		model::registerInletModel(_modelCreators);
 		model::registerOutletModel(_modelCreators);
+		model::registerMixerSplitterModel(_modelCreators);
 		model::registerGeneralRateModel(_modelCreators);
 		model::registerLumpedRateModelWithPores(_modelCreators);
 		model::registerLumpedRateModelWithoutPores(_modelCreators);

--- a/src/libcadet/model/MixerSplitterModel.cpp
+++ b/src/libcadet/model/MixerSplitterModel.cpp
@@ -1,0 +1,244 @@
+// =============================================================================
+//  CADET - The Chromatography Analysis and Design Toolkit
+//
+//  Copyright © 2008-2019: The CADET Authors
+//            Please see the AUTHORS and CONTRIBUTORS file.
+//
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+#include "model/MixerSplitterModel.hpp"
+#include "ParamReaderHelper.hpp"
+#include "cadet/Exceptions.hpp"
+#include "cadet/SolutionRecorder.hpp"
+#include "SimulationTypes.hpp"
+
+#include "ConfigurationHelper.hpp"
+#include "ParamIdUtil.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+
+#include "LoggingUtils.hpp"
+#include "Logging.hpp"
+
+#include "AdUtils.hpp"
+
+
+inline void residual(double const* y, unsigned int nComp, double* res)
+{
+	std::copy(y, y + nComp, res);
+}
+
+
+namespace cadet
+{
+
+namespace model
+{
+
+MixerSplitterModel::MixerSplitterModel(UnitOpIdx unitOpIdx) : _unitOpIdx(unitOpIdx)
+{
+}
+
+MixerSplitterModel::~MixerSplitterModel() CADET_NOEXCEPT
+{
+}
+
+unsigned int MixerSplitterModel::numDofs() const CADET_NOEXCEPT
+{
+	return _nComp;
+}
+
+unsigned int MixerSplitterModel::numPureDofs() const CADET_NOEXCEPT
+{
+	return 0;
+}
+
+bool MixerSplitterModel::usesAD() const CADET_NOEXCEPT
+{
+	return false;
+}
+
+void MixerSplitterModel::setFlowRates(active const* in, active const* out) CADET_NOEXCEPT 
+{ 
+	_flowRateIn = in[0];
+	_flowRateOut = out[0];
+}
+
+bool MixerSplitterModel::configureModelDiscretization(IParameterProvider& paramProvider, IConfigHelper& helper)
+{
+	_nComp = paramProvider.getInt("NCOMP");
+	return true;
+}
+
+bool MixerSplitterModel::configure(IParameterProvider& paramProvider)
+{
+	return true;
+}
+
+void MixerSplitterModel::setSectionTimes(double const* secTimes, bool const* secContinuity, unsigned int nSections) { }
+
+std::unordered_map<ParameterId, double> MixerSplitterModel::getAllParameterValues() const
+{
+	return std::unordered_map<ParameterId, double>();
+}
+
+bool MixerSplitterModel::hasParameter(const ParameterId& pId) const
+{
+	return false;
+}
+
+double MixerSplitterModel::getParameterDouble(const ParameterId& pId) const
+{
+	return std::numeric_limits<double>::quiet_NaN();
+}
+
+bool MixerSplitterModel::setParameter(const ParameterId& pId, int value)
+{
+	return false;
+}
+
+bool MixerSplitterModel::setParameter(const ParameterId& pId, double value)
+{
+	return false;
+}
+
+bool MixerSplitterModel::setParameter(const ParameterId& pId, bool value)
+{
+	return false;
+}
+
+void MixerSplitterModel::setSensitiveParameterValue(const ParameterId& pId, double value)
+{
+}
+
+bool MixerSplitterModel::setSensitiveParameter(const ParameterId& pId, unsigned int adDirection, double adValue)
+{
+	return false;
+}
+
+void MixerSplitterModel::clearSensParams()
+{
+}
+
+unsigned int MixerSplitterModel::numSensParams() const
+{
+	return 0;
+}
+
+void MixerSplitterModel::useAnalyticJacobian(const bool analyticJac) { }
+void MixerSplitterModel::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, const AdJacobianParams& adJac) { }
+
+void MixerSplitterModel::reportSolution(ISolutionRecorder& recorder, double const* const solution) const
+{
+	Exporter expr(_nComp, solution);
+	recorder.beginUnitOperation(_unitOpIdx, *this, expr);
+	recorder.endUnitOperation();
+}
+
+void MixerSplitterModel::reportSolutionStructure(ISolutionRecorder& recorder) const
+{
+	Exporter expr(_nComp, nullptr);
+	recorder.unitOperationStructure(_unitOpIdx, *this, expr);
+}
+
+unsigned int MixerSplitterModel::requiredADdirs() const CADET_NOEXCEPT
+{
+	return 0;
+}
+
+void MixerSplitterModel::prepareADvectors(const AdJacobianParams& adJac) const { }
+
+void MixerSplitterModel::applyInitialCondition(const SimulationState& simState) const
+{
+	std::fill(simState.vecStateY, simState.vecStateY + _nComp, 0.0);
+	std::fill(simState.vecStateYdot, simState.vecStateYdot + _nComp, 0.0);
+}
+
+void MixerSplitterModel::readInitialCondition(IParameterProvider& paramProvider) { }
+
+int MixerSplitterModel::residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res)
+{
+	::residual(simState.vecStateY, _nComp, res);
+	return 0;
+}
+
+int MixerSplitterModel::residualWithJacobian(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, 
+	double* const res, const AdJacobianParams& adJac)
+{
+	// Jacobian is always identity
+	::residual(simState.vecStateY, _nComp, res);
+	return 0;
+}
+
+int MixerSplitterModel::residualSensFwdAdOnly(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, active* const adRes)
+{
+	for (unsigned int i = 0; i < _nComp; ++i)
+		adRes[i] = simState.vecStateY[i];
+
+	return 0;
+}
+
+int MixerSplitterModel::residualSensFwdCombine(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, 
+	const std::vector<const double*>& yS, const std::vector<const double*>& ySdot, const std::vector<double*>& resS, active const* adRes, 
+	double* const tmp1, double* const tmp2, double* const tmp3)
+{
+	// Directional derivative (dF / dy) * s does nothing since dF / dy = I (identity)
+	for (unsigned int param = 0; param < resS.size(); ++param)
+	{
+		double const* const y = yS[param];
+		double* const res = resS[param];
+		std::copy(y, y + _nComp, res);
+	}
+	return 0;
+}
+
+int MixerSplitterModel::residualSensFwdWithJacobian(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, const AdJacobianParams& adJac)
+{
+	for (unsigned int i = 0; i < _nComp; ++i)
+		adJac.adRes[i] = simState.vecStateY[i];
+
+	return 0;
+}
+
+void MixerSplitterModel::initializeSensitivityStates(const std::vector<double*>& vecSensY) const { }
+
+void MixerSplitterModel::consistentInitialSensitivity(const ActiveSimulationTime& simTime, const ConstSimulationState& simState,
+	std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes)
+{
+	// Nothing to do here as inlet DOFs are initialized by ModelSystem
+}
+
+void MixerSplitterModel::leanConsistentInitialSensitivity(const ActiveSimulationTime& simTime, const ConstSimulationState& simState,
+	std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes)
+{
+	// Nothing to do here as inlet DOFs are initialized by ModelSystem
+}
+
+void MixerSplitterModel::multiplyWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* yS, double alpha, double beta, double* ret)
+{
+	// dF / dy = I (identity matrix)
+	for (unsigned int i = 0; i < _nComp; ++i)
+	{
+		ret[i] = alpha * yS[i] + beta * ret[i];
+	}
+}
+
+void MixerSplitterModel::multiplyWithDerivativeJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* sDot, double* ret)
+{
+	std::fill_n(ret, numDofs(), 0.0);
+}
+
+void registerMixerSplitterModel(std::unordered_map<std::string, std::function<IUnitOperation*(UnitOpIdx)>>& models)
+{
+	models[MixerSplitterModel::identifier()] = [](UnitOpIdx uoId) { return new MixerSplitterModel(uoId); };
+}
+
+}  // namespace model
+
+}  // namespace cadet

--- a/src/libcadet/model/MixerSplitterModel.cpp
+++ b/src/libcadet/model/MixerSplitterModel.cpp
@@ -1,7 +1,7 @@
 // =============================================================================
-//  CADET - The Chromatography Analysis and Design Toolkit
+//  CADET
 //
-//  Copyright © 2008-2019: The CADET Authors
+//  Copyright © 2008-2021: The CADET Authors
 //            Please see the AUTHORS and CONTRIBUTORS file.
 //
 //  All rights reserved. This program and the accompanying materials
@@ -62,12 +62,6 @@ unsigned int MixerSplitterModel::numPureDofs() const CADET_NOEXCEPT
 bool MixerSplitterModel::usesAD() const CADET_NOEXCEPT
 {
 	return false;
-}
-
-void MixerSplitterModel::setFlowRates(active const* in, active const* out) CADET_NOEXCEPT 
-{ 
-	_flowRateIn = in[0];
-	_flowRateOut = out[0];
 }
 
 bool MixerSplitterModel::configureModelDiscretization(IParameterProvider& paramProvider, IConfigHelper& helper)
@@ -132,7 +126,7 @@ unsigned int MixerSplitterModel::numSensParams() const
 }
 
 void MixerSplitterModel::useAnalyticJacobian(const bool analyticJac) { }
-void MixerSplitterModel::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, const AdJacobianParams& adJac) { }
+void MixerSplitterModel::notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, const ConstSimulationState& simState, const AdJacobianParams& adJac) { }
 
 void MixerSplitterModel::reportSolution(ISolutionRecorder& recorder, double const* const solution) const
 {
@@ -162,21 +156,21 @@ void MixerSplitterModel::applyInitialCondition(const SimulationState& simState) 
 
 void MixerSplitterModel::readInitialCondition(IParameterProvider& paramProvider) { }
 
-int MixerSplitterModel::residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res)
+int MixerSplitterModel::residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res, util::ThreadLocalStorage& threadLocalMem)
 {
 	::residual(simState.vecStateY, _nComp, res);
 	return 0;
 }
 
-int MixerSplitterModel::residualWithJacobian(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, 
-	double* const res, const AdJacobianParams& adJac)
+int MixerSplitterModel::residualWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, 
+	double* const res, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem)
 {
 	// Jacobian is always identity
 	::residual(simState.vecStateY, _nComp, res);
 	return 0;
 }
 
-int MixerSplitterModel::residualSensFwdAdOnly(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, active* const adRes)
+int MixerSplitterModel::residualSensFwdAdOnly(const SimulationTime& simTime, const ConstSimulationState& simState, active* const adRes, util::ThreadLocalStorage& threadLocalMem)
 {
 	for (unsigned int i = 0; i < _nComp; ++i)
 		adRes[i] = simState.vecStateY[i];
@@ -184,7 +178,7 @@ int MixerSplitterModel::residualSensFwdAdOnly(const ActiveSimulationTime& simTim
 	return 0;
 }
 
-int MixerSplitterModel::residualSensFwdCombine(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, 
+int MixerSplitterModel::residualSensFwdCombine(const SimulationTime& simTime, const ConstSimulationState& simState, 
 	const std::vector<const double*>& yS, const std::vector<const double*>& ySdot, const std::vector<double*>& resS, active const* adRes, 
 	double* const tmp1, double* const tmp2, double* const tmp3)
 {
@@ -198,7 +192,7 @@ int MixerSplitterModel::residualSensFwdCombine(const ActiveSimulationTime& simTi
 	return 0;
 }
 
-int MixerSplitterModel::residualSensFwdWithJacobian(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, const AdJacobianParams& adJac)
+int MixerSplitterModel::residualSensFwdWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, const AdJacobianParams& adJac, util::ThreadLocalStorage& threadLocalMem)
 {
 	for (unsigned int i = 0; i < _nComp; ++i)
 		adJac.adRes[i] = simState.vecStateY[i];
@@ -208,14 +202,14 @@ int MixerSplitterModel::residualSensFwdWithJacobian(const ActiveSimulationTime& 
 
 void MixerSplitterModel::initializeSensitivityStates(const std::vector<double*>& vecSensY) const { }
 
-void MixerSplitterModel::consistentInitialSensitivity(const ActiveSimulationTime& simTime, const ConstSimulationState& simState,
-	std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes)
+void MixerSplitterModel::consistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
+	std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem)
 {
 	// Nothing to do here as inlet DOFs are initialized by ModelSystem
 }
 
-void MixerSplitterModel::leanConsistentInitialSensitivity(const ActiveSimulationTime& simTime, const ConstSimulationState& simState,
-	std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes)
+void MixerSplitterModel::leanConsistentInitialSensitivity(const SimulationTime& simTime, const ConstSimulationState& simState,
+	std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes, util::ThreadLocalStorage& threadLocalMem)
 {
 	// Nothing to do here as inlet DOFs are initialized by ModelSystem
 }

--- a/src/libcadet/model/MixerSplitterModel.cpp
+++ b/src/libcadet/model/MixerSplitterModel.cpp
@@ -51,12 +51,12 @@ MixerSplitterModel::~MixerSplitterModel() CADET_NOEXCEPT
 
 unsigned int MixerSplitterModel::numDofs() const CADET_NOEXCEPT
 {
-	return _nComp;
+	return 2 * _nComp;
 }
 
 unsigned int MixerSplitterModel::numPureDofs() const CADET_NOEXCEPT
 {
-	return 0;
+	return _nComp;
 }
 
 bool MixerSplitterModel::usesAD() const CADET_NOEXCEPT
@@ -226,6 +226,16 @@ void MixerSplitterModel::multiplyWithJacobian(const SimulationTime& simTime, con
 void MixerSplitterModel::multiplyWithDerivativeJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* sDot, double* ret)
 {
 	std::fill_n(ret, numDofs(), 0.0);
+}
+
+int MixerSplitterModel::linearSolve(double t, double alpha, double tol, double* const rhs, double const* const weight,
+	const ConstSimulationState& simState)
+{
+	// Handle inlet equations by backsubstitution
+	for (unsigned int i = 0; i < _nComp; ++i)
+	{
+		rhs[i + _nComp] += rhs[i];
+	}
 }
 
 void registerMixerSplitterModel(std::unordered_map<std::string, std::function<IUnitOperation*(UnitOpIdx)>>& models)

--- a/src/libcadet/model/MixerSplitterModel.hpp
+++ b/src/libcadet/model/MixerSplitterModel.hpp
@@ -97,7 +97,7 @@ public:
 
 	// linearSolve and assembleAndPrepareDAEJacobian are null operations since there are only inlet DOFs, which are treated by ModelSystem
 	virtual int linearSolve(double t, double alpha, double tol, double* const rhs, double const* const weight,
-		const ConstSimulationState& simState) { return 0; }
+		const ConstSimulationState& simState);
 
 	virtual void prepareADvectors(const AdJacobianParams& adJac) const;
 
@@ -182,9 +182,9 @@ protected:
 			return _data;
 		}
 		virtual double const* outlet(unsigned int port, unsigned int& stride) const
-		{n
+		{
 			stride = 1;
-			return _data;
+			return _data + _nComp;
 		}
 
 		virtual StateOrdering const* concentrationOrdering(unsigned int& len) const

--- a/src/libcadet/model/MixerSplitterModel.hpp
+++ b/src/libcadet/model/MixerSplitterModel.hpp
@@ -1,0 +1,236 @@
+// =============================================================================
+//  CADET - The Chromatography Analysis and Design Toolkit
+//  
+//  Copyright © 2008-2019: The CADET Authors
+//            Please see the AUTHORS and CONTRIBUTORS file.
+//  
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+/**
+ * @file 
+ * Defines the mixer/splitter model.
+ */
+
+#ifndef LIBCADET_MIXERSPLITTERMODEL_HPP_
+#define LIBCADET_MIXERSPLITTERMODEL_HPP_
+
+#include "cadet/SolutionExporter.hpp"
+
+#include "UnitOperation.hpp"
+#include "AutoDiff.hpp"
+#include "ParamIdUtil.hpp"
+#include "model/ModelUtils.hpp"
+
+#include <array>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace cadet
+{
+
+namespace model
+{
+
+/**
+ * @brief Mixer/Splitter model
+ * @details This unit operation is for recombination of streams
+ */
+class MixerSplitterModel : public IUnitOperation
+{
+public:
+
+	MixerSplitterModel(UnitOpIdx unitOpIdx);
+	virtual ~MixerSplitterModel() CADET_NOEXCEPT;
+
+	virtual unsigned int numDofs() const CADET_NOEXCEPT;
+	virtual unsigned int numPureDofs() const CADET_NOEXCEPT;
+	virtual bool usesAD() const CADET_NOEXCEPT;
+	virtual unsigned int requiredADdirs() const CADET_NOEXCEPT;
+
+	virtual UnitOpIdx unitOperationId() const CADET_NOEXCEPT { return _unitOpIdx; }
+	virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
+	virtual void setFlowRates(active const* in, active const* out) CADET_NOEXCEPT;
+	virtual unsigned int numInletPorts() const CADET_NOEXCEPT { return 1; }
+	virtual unsigned int numOutletPorts() const CADET_NOEXCEPT { return 1; }
+	virtual bool canAccumulate() const CADET_NOEXCEPT { return false; }
+
+	static const char* identifier() { return "MIXER_SPLITTER"; }
+	virtual const char* unitOperationName() const CADET_NOEXCEPT { return "MIXER_SPLITTER"; }
+
+	virtual bool configureModelDiscretization(IParameterProvider& paramProvider, IConfigHelper& helper);
+	virtual bool configure(IParameterProvider& paramProvider);
+	virtual void notifyDiscontinuousSectionTransition(double t, unsigned int secIdx, const AdJacobianParams& adJac);
+	
+	virtual std::unordered_map<ParameterId, double> getAllParameterValues() const;
+	virtual bool hasParameter(const ParameterId& pId) const;
+	virtual double getParameterDouble(const ParameterId& pId) const;
+
+	virtual bool setParameter(const ParameterId& pId, int value);
+	virtual bool setParameter(const ParameterId& pId, double value);
+	virtual bool setParameter(const ParameterId& pId, bool value);
+
+	virtual bool setSensitiveParameter(const ParameterId& pId, unsigned int adDirection, double adValue);
+	virtual void setSensitiveParameterValue(const ParameterId& id, double value);
+
+	virtual void clearSensParams();
+	virtual unsigned int numSensParams() const;
+
+	virtual void useAnalyticJacobian(const bool analyticJac);
+
+	virtual void reportSolution(ISolutionRecorder& recorder, double const* const solution) const;
+	virtual void reportSolutionStructure(ISolutionRecorder& recorder) const;
+
+	virtual int residual(const SimulationTime& simTime, const ConstSimulationState& simState, double* const res);
+	virtual int residualWithJacobian(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, double* const res, const AdJacobianParams& adJac);
+	virtual int residualSensFwdAdOnly(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, active* const adRes);
+	virtual int residualSensFwdWithJacobian(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, const AdJacobianParams& adJac);
+
+	virtual int residualSensFwdCombine(const ActiveSimulationTime& simTime, const ConstSimulationState& simState, 
+		const std::vector<const double*>& yS, const std::vector<const double*>& ySdot, const std::vector<double*>& resS, active const* adRes, 
+		double* const tmp1, double* const tmp2, double* const tmp3);
+
+
+	// linearSolve and assembleAndPrepareDAEJacobian are null operations since there are only inlet DOFs, which are treated by ModelSystem
+	virtual int linearSolve(double t, double timeFactor, double alpha, double tol, double* const rhs, double const* const weight,
+		const ConstSimulationState& simState) { return 0; }
+
+	virtual void prepareADvectors(const AdJacobianParams& adJac) const;
+
+	virtual void applyInitialCondition(const SimulationState& simState) const;
+	virtual void readInitialCondition(IParameterProvider& paramProvider);
+
+	virtual void consistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol) { }
+	virtual void consistentInitialTimeDerivative(const SimulationTime& simTime, double const* vecStateY, double* const vecStateYdot) { }
+
+	virtual void consistentInitialSensitivity(const ActiveSimulationTime& simTime, const ConstSimulationState& simState,
+		std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes);
+	virtual void initializeSensitivityStates(const std::vector<double*>& vecSensY) const;
+
+	virtual void leanConsistentInitialState(const SimulationTime& simTime, double* const vecStateY, const AdJacobianParams& adJac, double errorTol) { }
+	virtual void leanConsistentInitialTimeDerivative(double t, double timeFactor, double const* const vecStateY, double* const vecStateYdot, double* const res) { }
+
+	virtual void leanConsistentInitialSensitivity(const ActiveSimulationTime& simTime, const ConstSimulationState& simState,
+		std::vector<double*>& vecSensY, std::vector<double*>& vecSensYdot, active const* const adRes);
+
+	virtual void setExternalFunctions(IExternalFunction** extFuns, unsigned int size) { }
+
+	virtual void multiplyWithJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* yS, double alpha, double beta, double* ret);
+	virtual void multiplyWithDerivativeJacobian(const SimulationTime& simTime, const ConstSimulationState& simState, double const* sDot, double* ret);
+
+	virtual bool hasInlet() const CADET_NOEXCEPT { return true; }
+	virtual bool hasOutlet() const CADET_NOEXCEPT { return true; }
+
+	virtual unsigned int localOutletComponentIndex(unsigned int port) const CADET_NOEXCEPT { return 0; }
+	virtual unsigned int localOutletComponentStride(unsigned int port) const CADET_NOEXCEPT { return 1; }
+	virtual unsigned int localInletComponentIndex(unsigned int port) const CADET_NOEXCEPT { return 0; }
+	virtual unsigned int localInletComponentStride(unsigned int port) const CADET_NOEXCEPT { return 1; }
+
+	virtual void setSectionTimes(double const* secTimes, bool const* secContinuity, unsigned int nSections);
+
+	virtual void expandErrorTol(double const* errorSpec, unsigned int errorSpecSize, double* expandOut) { }
+
+#ifdef CADET_BENCHMARK_MODE
+	virtual std::vector<double> benchmarkTimings() const { return std::vector<double>(0); }
+	virtual char const* const* benchmarkDescriptions() const { return nullptr; }
+#endif
+
+    inline void setFlowRates(double in, double out) CADET_NOEXCEPT { _flowRateIn = in; _flowRateOut = out; }
+
+protected:
+
+	UnitOpIdx _unitOpIdx; //!< Unit operation index
+	unsigned int _nComp; //!< Number of components
+
+	active _flowRateIn; //!< Volumetric flow rate of incoming stream
+	active _flowRateOut; //!< Volumetric flow rate of drawn outgoing stream
+
+	class Exporter : public ISolutionExporter
+	{
+	public:
+
+		Exporter(unsigned int nComp, double const* data) : _data(data), _nComp(nComp) { }
+
+		virtual bool hasParticleFlux() const CADET_NOEXCEPT { return false; }
+		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return false; }
+		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return false; }
+		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
+
+		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
+		virtual unsigned int numAxialCells() const CADET_NOEXCEPT { return 0; }
+		virtual unsigned int numRadialCells() const CADET_NOEXCEPT { return 0; }
+		virtual unsigned int numInletPorts() const CADET_NOEXCEPT { return 1; }
+		virtual unsigned int numOutletPorts() const CADET_NOEXCEPT { return 1; }
+		virtual unsigned int numParticleTypes() const CADET_NOEXCEPT { return 0; }
+		virtual unsigned int numParticleShells(unsigned int parType) const CADET_NOEXCEPT { return 0; }
+		virtual unsigned int numBoundStates(unsigned int parType) const CADET_NOEXCEPT { return 0; }
+		virtual unsigned int numBulkDofs() const CADET_NOEXCEPT { return _nComp; }
+		virtual unsigned int numParticleMobilePhaseDofs(unsigned int parType) const CADET_NOEXCEPT { return 0; }
+		virtual unsigned int numSolidPhaseDofs(unsigned int parType) const CADET_NOEXCEPT { return 0; }
+		virtual unsigned int numFluxDofs() const CADET_NOEXCEPT { return 0; }
+		virtual unsigned int numVolumeDofs() const CADET_NOEXCEPT { return 0; }
+
+		virtual double const* concentration() const { return _data; }
+		virtual double const* flux() const { return nullptr; }
+		virtual double const* particleMobilePhase(unsigned int parType) const { return nullptr; }
+		virtual double const* solidPhase(unsigned int parType) const { return nullptr; }
+		virtual double const* volume() const { return nullptr; }
+		virtual double const* inlet(unsigned int port, unsigned int& stride) const
+		{
+			stride = 1;
+			return _data;
+		}
+		virtual double const* outlet(unsigned int port, unsigned int& stride) const
+		{
+			stride = 1;
+			return _data;
+		}
+
+		virtual StateOrdering const* concentrationOrdering(unsigned int& len) const
+		{
+			len = _concentrationOrdering.size();
+			return _concentrationOrdering.data();
+		}
+
+		virtual StateOrdering const* fluxOrdering(unsigned int& len) const
+		{
+			len = 0;
+			return nullptr;
+		}
+
+		virtual StateOrdering const* mobilePhaseOrdering(unsigned int& len) const
+		{
+			len = 0;
+			return nullptr;
+		}
+
+		virtual StateOrdering const* solidPhaseOrdering(unsigned int& len) const
+		{
+			len = 0;
+			return nullptr;
+		}
+
+		virtual unsigned int bulkMobilePhaseStride() const { return _nComp; }
+		virtual unsigned int particleMobilePhaseStride(unsigned int parType) const { return 0; }
+		virtual unsigned int solidPhaseStride(unsigned int parType) const { return 0; }
+
+		virtual void axialCoordinates(double* coords) const { }
+		virtual void radialCoordinates(double* coords) const { }
+		virtual void particleCoordinates(unsigned int parType, double* coords) const { }
+
+	protected:
+		double const* const _data;
+		unsigned int _nComp;
+
+		const std::array<StateOrdering, 1> _concentrationOrdering = { { StateOrdering::Component } };
+	};
+};
+
+} // namespace model
+} // namespace cadet
+
+#endif  // LIBCADET_MIXERSPLITTERMODEL_HPP_


### PR DESCRIPTION
This is my first try at anything C++. Please be gentle! ;-)

As mentioned in #40, the goal is to implement a Unit that has zero volume but can be used to mix and reconnect streams between UnitOperations.

I took the OutletModel as a template and 
- enabled outlets
- added setFlowRates() function from StirredTankModel

### What works
- It compiles! 
- Simulations work if there is only one ingoing stream active at the time.
- The stream can (dynamically) be separated into different outgoing streams (also with fractional flow rates)

### What does not work
- Having more than one active input at a time leads to a TimeOut.

I guess I forgot to implement something related to the flow rates.
