### PR TITLE
Add simple C interface to libcadet

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,5 @@
 GE Healthcare sponsored development of core-shell beads, multiple particle types, and 2D general rate model
 Sartorius sponsored development of particle geometries
-Bayer AG contributed to bugfixes, initial C API
+Bayer AG contributed to bugfixes, initial C API, initial Python frontend
 
 Follow the lead, become a contributor by sending a pull request or a patch.

--- a/include/cadet/LibVersionInfo.hpp
+++ b/include/cadet/LibVersionInfo.hpp
@@ -21,59 +21,6 @@
 #include "cadet/LibExportImport.hpp"
 #include "cadet/cadetCompilerInfo.hpp"
 
-extern "C"
-{
-	/**
-	 * @brief Returns the version string of the libcadet library
-	 * @return Version string
-	 */
-	CADET_API const char* cadetGetLibraryVersion();
-
-	/**
-	 * @brief Returns the git commit hash of the source which was used to build the binaries
-	 * @return Git commit hash as string
-	 */
-	CADET_API const char* cadetGetLibraryCommitHash();
-
-	/**
-	 * @brief Returns the git refspec of the source which was used to build the binaries
-	 * @return Git refspec
-	 */
-	CADET_API const char* cadetGetLibraryBranchRefspec();
-
-	/**
-	 * @brief Returns the versions of the dependencies used for building the binaries
-	 * @details The format is DEPNAME1=VERSION;DEPNAME2=VERSION; where each dependency is
-	 *          terminated by a semicolon.
-	 * @return Dependency versions string
-	 */
-	CADET_API const char* cadetGetLibraryDependencyVersions();
-
-	/**
-	 * @brief Returns the build type (Debug, Release, RelWithDebInfo, RelMinSize)
-	 * @return Build type
-	 */
-	CADET_API const char* cadetGetLibraryBuildType();
-
-	/**
-	 * @brief Returns the compiler including its version used for building the library
-	 * @return Compiler and its version
-	 */
-	CADET_API const char* cadetGetLibraryCompiler();
-
-	/**
-	 * @brief Returns the compiler flags used for building the library
-	 * @return Compiler flags
-	 */
-	CADET_API const char* cadetGetLibraryCompilerFlags();
-
-	/**
-	 * @brief Returns the git refspec of the source which was used to build the binaries
-	 * @return Git refspec
-	 */
-	CADET_API const char* cadetGetLibraryBuildHost();
-}
-
 namespace cadet
 {
 

--- a/include/cadet/Logging.hpp
+++ b/include/cadet/Logging.hpp
@@ -165,27 +165,4 @@ namespace cadet
 
 } // namespace cadet
 
-extern "C"
-{
-	/**
-	 * @brief Sets the log receiver replacing any previously set receiver
-	 * @param [in] recv Pointer to ILogReceiver implementation or @c nullptr
-	 */
-	CADET_API void cadetSetLogReceiver(cadet::ILogReceiver* const recv);
-
-	/**
-	 * @brief Sets the log level
-	 * @details All messages on a lower log level (i.e., higher severity or information content)
-	 *          are filtered out.
-	 * @param [in] lvl New log level
-	 */
-	CADET_API void cadetSetLogLevel(unsigned int lvl);
-
-	/**
-	 * @brief Returns the current log level
-	 * @return Current log level
-	 */
-	CADET_API unsigned int cadetGetLogLevel();
-}
-
 #endif  // LIBCADET_LOGGING_HPP_

--- a/include/cadet/cadet.h
+++ b/include/cadet/cadet.h
@@ -1,0 +1,410 @@
+// =============================================================================
+//  CADET - The Chromatography Analysis and Design Toolkit
+//  
+//  Copyright © 2008-2020: The CADET Authors
+//            Please see the AUTHORS and CONTRIBUTORS file.
+//  
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+/**
+ * @file 
+ * Defines the C API of the library.
+ */
+
+#ifndef LIBCADET_CAPI_HPP_
+#define LIBCADET_CAPI_HPP_
+
+#include "cadet/LibExportImport.hpp"
+
+#include <stdint.h>
+
+#define CADET_OK(x) (x >= 0)
+#define CADET_ERR(x) (x < 0)
+
+extern "C"
+{
+
+	/**
+	 * @brief Returns the version string of the libcadet library
+	 * @return Version string
+	 */
+	CADET_API const char* cdtGetLibraryVersion();
+
+	/**
+	 * @brief Returns the git commit hash of the source which was used to build the binaries
+	 * @return Git commit hash as string
+	 */
+	CADET_API const char* cdtGetLibraryCommitHash();
+
+	/**
+	 * @brief Returns the git refspec of the source which was used to build the binaries
+	 * @return Git refspec
+	 */
+	CADET_API const char* cdtGetLibraryBranchRefspec();
+
+	/**
+	 * @brief Returns the versions of the dependencies used for building the binaries
+	 * @details The format is DEPNAME1=VERSION;DEPNAME2=VERSION; where each dependency is
+	 *          terminated by a semicolon.
+	 * @return Dependency versions string
+	 */
+	CADET_API const char* cdtGetLibraryDependencyVersions();
+
+	/**
+	 * @brief Returns the build type (Debug, Release, RelWithDebInfo, RelMinSize)
+	 * @return Build type
+	 */
+	CADET_API const char* cdtGetLibraryBuildType();
+
+	/**
+	 * @brief Returns the compiler including its version used for building the library
+	 * @return Compiler and its version
+	 */
+	CADET_API const char* cdtGetLibraryCompiler();
+
+	/**
+	 * @brief Returns the compiler flags used for building the library
+	 * @return Compiler flags
+	 */
+	CADET_API const char* cdtGetLibraryCompilerFlags();
+
+	/**
+	 * @brief Returns the git refspec of the source which was used to build the binaries
+	 * @return Git refspec
+	 */
+	CADET_API const char* cdtGetLibraryBuildHost();
+
+
+
+
+	/**
+	 * @brief LogLevel represents the severity of log messages
+	 * @details The levels are nested, such that the highest level (Trace) includes all lower levels.
+	 */
+	enum cdtLogLevel
+	{
+		/**
+		 * @brief Nothing is logged
+		 */
+		cdtLogLevelNone = 0,
+		/**
+		 * @brief Non-recoverable (fatal) error (terminates program / simulation)
+		 */
+		cdtLogLevelFatal = 1,
+		/**
+		 * @brief Error, which may be recoverable
+		 */
+		cdtLogLevelError = 2,
+		/**
+		 * @brief Warning
+		 */
+		cdtLogLevelWarning = 3,
+		/**
+		 * @brief Normal output (informative)
+		 */
+		cdtLogLevelNormal = 4,
+		/**
+		 * @brief Additional info output
+		 */
+		cdtLogLevelInfo = 5,
+		/**
+		 * @brief Debug messages and values of (intermediate) variables or calculations
+		 */
+		cdtLogLevelDebug = 6,
+		/**
+		 * @brief Full trace including entering / leaving functions
+		 */
+		cdtLogLevelTrace = 7,
+	};
+
+
+	/**
+	 * @brief Callback for each log message
+	 * @param [in] file Name of the file
+	 * @param [in] func Name of the function
+	 * @param [in] line Line number
+	 * @param [in] lvl Log level encoding the severity of the message
+	 * @param [in] lvlStr Name of the log level
+	 * @param [in] message Actual log message
+	 */
+	typedef void (*cdtLogHandler)(const char* file, const char* func, const unsigned int line, int lvl, const char* lvlStr, const char* message);
+
+	/**
+	 * @brief Sets the log receiver replacing any previously set receiver
+	 * @param [in] recv Pointer to handler implementation or @c NULL
+	 */
+	CADET_API void cdtSetLogReceiver(cdtLogHandler recv);
+
+	/**
+	 * @brief Sets the log level
+	 * @details All messages on a lower log level (i.e., higher severity or information content)
+	 *          are filtered out.
+	 * @param [in] lvl New log level
+	 */
+	CADET_API void cdtSetLogLevel(int lvl);
+
+	/**
+	 * @brief Returns the current log level
+	 * @return Current log level
+	 */
+	CADET_API int cdtGetLogLevel();
+
+
+
+	/**
+	 * @brief Return and error codes
+	 */
+	enum cdtErrors
+	{
+		/**
+		 * @brief Input arguments invalid
+		 */
+		cdtErrorInvalidInputs = -2,
+		/**
+		 * @brief General error
+		 */
+		cdtError = -1,
+		/**
+		 * @brief Success
+		 */
+		cdtOK = 0
+	};
+
+	/**
+	 * Result of operation (in general: < 0 indicates failure, >= 0 indicates success)
+	 */
+	typedef int cdtResult;
+
+
+
+	/**
+	 * @brief ParameterProvider interface is used for querying parameters and data
+	 */
+	typedef struct
+	{
+		/**
+		 * @brief User data passed to every callback function
+		 */
+		void* userData;
+
+		/**
+		 * @brief Returns the value of a parameter of type double
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [out] val Value of the parameter
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getDouble)(void* userData, const char* paramName, double* val);
+
+		/**
+		 * @brief Returns the value of a parameter of type int
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [out] val Value of the parameter
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getInt)(void* userData, const char* paramName, int* val);
+
+		/**
+		 * @brief Returns the value of a parameter of type bool
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [out] val Value of the parameter (@c 0 if false, @c 1 if true)
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getBool)(void* userData, const char* paramName, uint8_t* val);
+
+		/**
+		 * @brief Returns the value of a parameter of type string
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [out] val Value of the parameter (the string is copied internally)
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getString)(void* userData, const char* paramName, char const** val);
+
+		/**
+		 * @brief Returns a parameter array of type double
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [out] numElements Number of elements in the array
+		 * @param [out] vals Pointer to contiguous array of elements (will be copied internally)
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getDoubleArray)(void* userData, const char* paramName, int* numElements, double** vals);
+
+		/**
+		 * @brief Returns a parameter array of type int
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [out] numElements Number of elements in the array
+		 * @param [out] vals Pointer to contiguous array of elements (will be copied internally)
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getIntArray)(void* userData, const char* paramName, int* numElements, int** vals);
+
+		/**
+		 * @brief Returns a parameter array of type bool
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [out] numElements Number of elements in the array
+		 * @param [out] vals Pointer to contiguous array of elements (will be copied internally)
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getBoolArray)(void* userData, const char* paramName, int* numElements, uint8_t** vals);
+
+		/**
+		 * @brief Returns a parameter array of type string
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [out] numElements Number of elements in the array
+		 * @param [out] vals Pointer to contiguous array of elements (will be copied internally)
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getStringArray)(void* userData, const char* paramName, int* numElements, char const*** vals);
+
+		/**
+		 * @brief Returns an item of a parameter array of type double
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [in] idx Index of the requested element
+		 * @param [out] val Value
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getDoubleArrayItem)(void* userData, const char* paramName, int idx, double* val);
+
+		/**
+		 * @brief Returns an item of a parameter array of type int
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [in] idx Index of the requested element
+		 * @param [out] val Value
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getIntArrayItem)(void* userData, const char* paramName, int idx, int* val);
+
+		/**
+		 * @brief Returns an item of a parameter array of type bool
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [in] idx Index of the requested element
+		 * @param [out] val Value
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getBoolArrayItem)(void* userData, const char* paramName, int idx, uint8_t* val);
+
+		/**
+		 * @brief Returns an item of a parameter array of type string
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [in] idx Index of the requested element
+		 * @param [out] val Value (will be copied internally)
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*getStringArrayItem)(void* userData, const char* paramName, int idx, char const** val);
+
+		/**
+		 * @brief Checks whether a given parameter or scope exists
+		 * @param [in] userData User supplied data
+		 * @param [in] elemName Name of the parameter or scope
+		 * @return Non-zero if the parameter exists, otherwise @c 0
+		 */
+		int (*exists)(void* userData, const char* elemName);
+
+		/**
+		 * @brief Checks whether a given parameter is an array
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @param [out] res Non-zero if the parameter is an array, otherwise @c 0
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*isArray)(void* userData, const char* paramName, uint8_t* res);
+
+		/**
+		 * @brief Returns the number of elements (of an array) in a given field
+		 * @param [in] userData User supplied data
+		 * @param [in] paramName Name of the parameter
+		 * @return Number of elements in the given field (or non-positive number if field does not exist)
+		 */
+		int (*numElements)(void* userData, const char* paramName);
+
+		/**
+		 * @brief Changes to a given namespace subscope
+		 * @param [in] userData User supplied data
+		 * @param [in] scope Name of the scope
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*pushScope)(void* userData, const char* scope);
+
+		/**
+		 * @brief Changes to the parent of the current namespace scope
+		 * @param [in] userData User supplied data
+		 * @return @c cdtOK on success, @c cdtError on error
+		 */
+		cdtResult (*popScope)(void* userData);
+
+	} cdtParameterProvider;
+
+
+
+
+	/**
+	 * Driver object
+	 */
+	typedef struct cdtDriver cdtDriver;
+
+	/**
+	 * Holds function pointers to API version 1
+	 */
+	typedef struct
+	{
+		/**
+		 * @brief Creates a driver that handles simulation on a high level
+		 * @return Driver handle or @c NULL if an error occurred
+		 */
+		cdtDriver* (*createDriver)(void);
+
+		/**
+		 * @brief Deletes a driver created by createDriver
+		 * @param[in] drv Driver handle
+		 */
+		void (*deleteDriver)(cdtDriver* drv);
+
+		/**
+		 * @brief Runs a full simulation using the given driver and parameter provider
+		 * @param[in] drv Driver handle
+		 * @param[in] paramProvider Callback parameter provider
+		 * @return @c cdtOK on success, a negative value indicating the error otherwise
+		 */
+		cdtResult (*runSimulation)(cdtDriver* drv, cdtParameterProvider const* paramProvider);
+
+		/**
+		 * @brief Returns the solution of the last simulation
+		 * @details Before this function is called, a simulation has to be run successfully.
+		 *          The array pointers are only valid until a new simulation is started.
+		 * @param [in] drv Driver handle
+		 * @param [in] unitOpId ID of the unit operation whose solution is returned
+		 * @param [out] time Time array pointer
+		 * @param [out] data Data array pointer
+		 * @param [out] nTime Number of time points
+		 * @param [out] nPort Number of ports
+		 * @param [out] nComp Number of components
+		 */
+		cdtResult (*getSolutionOutlet)(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nPort, int* nComp);
+
+	} cdtAPIv010000;
+
+	/**
+	 * @brief      Queries API version 1.0.0, which is returned as a struct of function pointers
+	 * @param[out] ptr      Pointer to a matching function pointer struct that is populated if the API is available
+	 * @return     Success (>= 0) if the API is available, otherwise error (< 0)
+	 */
+	CADET_API cdtResult cdtGetAPIv010000(cdtAPIv010000* ptr);
+
+}
+
+#endif  // LIBCADET_CAPI_HPP_

--- a/include/common/Driver.hpp
+++ b/include/common/Driver.hpp
@@ -266,6 +266,8 @@ public:
 
 		// Create and configure model
 		cadet::IModelSystem* model = _builder->createSystem(pp);
+		if (!model)
+			throw InvalidParameterException("Invalid model");
 
 		// Hand model over to simulator
 		_sim->initializeModel(*model);

--- a/src/cadet-cli/cadet-cli.cpp
+++ b/src/cadet-cli/cadet-cli.cpp
@@ -350,8 +350,8 @@ int main(int argc, char** argv)
 
 	// Set LogLevel in library and locally
 	LogReceiver lr;
-	cadetSetLogReceiver(&lr);
-	cadetSetLogLevel(static_cast<typename std::underlying_type<cadet::LogLevel>::type>(logLevel));
+	cadet::setLogReceiver(&lr);
+	cadet::setLogLevel(logLevel);
 	setLocalLogLevel(logLevel);
 
 	// Obtain file extensions for selecting corresponding reader and writer

--- a/src/libcadet/CMakeLists.txt
+++ b/src/libcadet/CMakeLists.txt
@@ -106,6 +106,7 @@ set(LIBCADET_REACTIONMODEL_SOURCES
 set(LIBCADET_SOURCES
 	${CMAKE_CURRENT_BINARY_DIR}/VersionInfo.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/Logging.cpp
+	${CMAKE_SOURCE_DIR}/src/libcadet/api/CAPIv1.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/FactoryFuncs.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/ModelBuilderImpl.cpp
 	${CMAKE_SOURCE_DIR}/src/libcadet/SimulatorImpl.cpp

--- a/src/libcadet/ModelBuilderImpl.cpp
+++ b/src/libcadet/ModelBuilderImpl.cpp
@@ -20,6 +20,9 @@
 #include "model/ModelSystemImpl.hpp"
 #include "CompileTimeConfig.hpp"
 
+#include "LoggingUtils.hpp"
+#include "Logging.hpp"
+
 #include <sstream>
 #include <iomanip>
 
@@ -171,6 +174,7 @@ namespace cadet
 		if (it == _modelCreators.end())
 		{
 			// Model was not found
+			LOG(Error) << "Unknown unit type " << uoType << " for unit " << uoId;
 			return nullptr;
 		}
 
@@ -180,6 +184,7 @@ namespace cadet
 
 		if (!model->configureModelDiscretization(paramProvider, *this) || !model->configure(paramProvider))
 		{
+			LOG(Error) << "Configuration of unit " << uoId << "(" << uoType << ") failed";
 			delete model;
 			return nullptr;
 		}
@@ -193,6 +198,7 @@ namespace cadet
 		if (it == _modelCreators.end())
 		{
 			// Model was not found
+			LOG(Error) << "Unknown unit type " << uoType << " for unit " << uoId;
 			return nullptr;
 		}
 

--- a/src/libcadet/VersionInfo.cpp.in
+++ b/src/libcadet/VersionInfo.cpp.in
@@ -11,6 +11,7 @@
 // =============================================================================
 
 #include "cadet/LibVersionInfo.hpp"
+#include "cadet/cadet.h"
 
 namespace cadet
 {
@@ -67,42 +68,42 @@ namespace cadet
 extern "C"
 {
 	
-	CADET_API const char* cadetGetLibraryVersion()
+	CADET_API const char* cdtGetLibraryVersion()
 	{
 		return cadet::getLibraryVersion();
 	}
 
-	CADET_API const char* cadetGetLibraryCommitHash()
+	CADET_API const char* cdtGetLibraryCommitHash()
 	{
 		return cadet::getLibraryCommitHash();
 	}
 
-	CADET_API const char* cadetGetLibraryBranchRefspec()
+	CADET_API const char* cdtGetLibraryBranchRefspec()
 	{
 		return cadet::getLibraryBranchRefspec();
 	}
 	
-	CADET_API const char* cadetGetLibraryDependencyVersions()
+	CADET_API const char* cdtGetLibraryDependencyVersions()
 	{
 		return cadet::getLibraryDependencyVersions();
 	}
 
-	CADET_API const char* cadetGetLibraryBuildType()
+	CADET_API const char* cdtGetLibraryBuildType()
 	{
 		return cadet::getLibraryBuildType();
 	}
 
-	CADET_API const char* cadetGetLibraryCompiler()
+	CADET_API const char* cdtGetLibraryCompiler()
 	{
 		return cadet::getLibraryCompiler();
 	}
 
-	CADET_API const char* cadetGetLibraryCompilerFlags()
+	CADET_API const char* cdtGetLibraryCompilerFlags()
 	{
 		return cadet::getLibraryCompilerFlags();
 	}
 
-	CADET_API const char* cadetGetLibraryBuildHost()
+	CADET_API const char* cdtGetLibraryBuildHost()
 	{
 		return cadet::getLibraryBuildHost();
 	}

--- a/src/libcadet/api/CAPIv1.cpp
+++ b/src/libcadet/api/CAPIv1.cpp
@@ -1,0 +1,473 @@
+// =============================================================================
+//  CADET - The Chromatography Analysis and Design Toolkit
+//  
+//  Copyright © 2008-2020: The CADET Authors
+//            Please see the AUTHORS and CONTRIBUTORS file.
+//  
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+#include "cadet/cadet.h"
+
+#include "common/CompilerSpecific.hpp"
+#include "cadet/ParameterProvider.hpp"
+#include "cadet/Exceptions.hpp"
+#include "common/Driver.hpp"
+
+#include "LoggingUtils.hpp"
+#include "Logging.hpp"
+
+extern "C"
+{
+	struct cdtDriver
+	{
+		cadet::Driver* driver;
+	};
+}
+
+namespace cadet
+{
+
+namespace api
+{
+
+namespace v1
+{
+
+	cdtDriver* createDriver()
+	{
+		return new cdtDriver{ new cadet::Driver() };
+	}
+
+	void deleteDriver(cdtDriver* drv)
+	{
+		if (!drv)
+			return;
+		if (!drv->driver)
+			return;
+
+		delete drv->driver;
+		drv->driver = nullptr;
+	}
+
+	/**
+	 * @brief ParameterProvider implementation using C callback functions
+	 */
+	class CallbackParameterProvider : public IParameterProvider
+	{
+	public:
+
+		CallbackParameterProvider(const cdtParameterProvider& pp) : _pp(pp)
+		{
+			if (!pp.getDouble)
+				throw InvalidParameterException("ParameterProvider does not implement getDouble()");
+			if (!pp.getInt)
+				throw InvalidParameterException("ParameterProvider does not implement getInt()");
+			if (!pp.getBool)
+				throw InvalidParameterException("ParameterProvider does not implement getBool()");
+			if (!pp.getString)
+				throw InvalidParameterException("ParameterProvider does not implement getString()");
+			if (!pp.getDoubleArray && !pp.getDoubleArrayItem)
+				throw InvalidParameterException("ParameterProvider does neither implement getDoubleArray() nor getDoubleArrayItem()");
+			if (!pp.getIntArray && !pp.getIntArrayItem)
+				throw InvalidParameterException("ParameterProvider does neither implement getIntArray() nor getIntArrayItem()");
+			if (!pp.getBoolArray && !pp.getBoolArrayItem)
+				throw InvalidParameterException("ParameterProvider does neither implement getBoolArray() nor getBoolArrayItem()");
+			if (!pp.getStringArray && !pp.getStringArrayItem)
+				throw InvalidParameterException("ParameterProvider does neither implement getStringArray() nor getStringArrayItem()");
+			if (!pp.exists)
+				throw InvalidParameterException("ParameterProvider does not implement exists()");
+			if (!pp.isArray)
+				throw InvalidParameterException("ParameterProvider does not implement isArray()");
+			if (!pp.numElements)
+				throw InvalidParameterException("ParameterProvider does not implement numElements()");
+			if (!pp.pushScope)
+				throw InvalidParameterException("ParameterProvider does not implement pushScope()");
+			if (!pp.popScope)
+				throw InvalidParameterException("ParameterProvider does not implement popScope()");
+		}
+		virtual ~CallbackParameterProvider() CADET_NOEXCEPT { }
+
+		virtual double getDouble(const std::string& paramName)
+		{
+			double v = 0.0;
+			if (CADET_ERR(_pp.getDouble(_pp.userData, paramName.c_str(), &v)))
+				throw InvalidParameterException("Retrieving double parameter " + paramName + " failed");
+
+			LOG(Debug) << "GET scalar [double] " << paramName << ": " << v;
+			return v;
+		}
+
+		virtual int getInt(const std::string& paramName)
+		{
+			int v = 0;
+			if (CADET_ERR(_pp.getInt(_pp.userData, paramName.c_str(), &v)))
+				throw InvalidParameterException("Retrieving int parameter " + paramName + " failed");
+
+			LOG(Debug) << "GET scalar [int] " << paramName << ": " << v;
+			return v;
+		}
+
+		virtual uint64_t getUint64(const std::string& paramName)
+		{
+			throw std::logic_error("getUint64 not implemented");
+		}
+
+		virtual bool getBool(const std::string& paramName)
+		{
+			uint8_t v = 0;
+			if (CADET_ERR(_pp.getBool(_pp.userData, paramName.c_str(), &v)))
+				throw InvalidParameterException("Retrieving bool parameter " + paramName + " failed");
+
+			LOG(Debug) << "GET scalar [bool] " << paramName << ": " << bool(v);
+			return v;
+		}
+
+		virtual std::string getString(const std::string& paramName)
+		{
+			char const* v = nullptr;
+			if (CADET_ERR(_pp.getString(_pp.userData, paramName.c_str(), &v)))
+				throw InvalidParameterException("Retrieving string parameter " + paramName + " failed");
+
+			if (!v)
+				throw InvalidParameterException("Retrieving string parameter " + paramName + " failed (received nullptr)");
+
+			LOG(Debug) << "GET scalar [string] " << paramName << ": " << v << " (mem: " << static_cast<void*>(&v) << " " << static_cast<void const*>(v) << ")";
+			return std::string(v);
+		}
+
+		virtual std::vector<double> getDoubleArray(const std::string& paramName)
+		{
+			if (_pp.getDoubleArray)
+			{
+				int num = 0;
+				double* v = nullptr;
+				if (CADET_ERR(_pp.getDoubleArray(_pp.userData, paramName.c_str(), &num, &v)))
+				{
+					if (_pp.getDoubleArrayItem)
+						return getDoubleArrayElementwise(paramName);
+					else
+						throw InvalidParameterException("Retrieving double parameter array " + paramName + " failed");
+				}
+
+				LOG(Debug) << "GET array [double] " << paramName << ": " << log::VectorPtr<double>(v, num);
+				return std::vector<double>(v, v + num);
+			}
+
+			return getDoubleArrayElementwise(paramName);
+		}
+
+		virtual std::vector<int> getIntArray(const std::string& paramName)
+		{
+			if (_pp.getIntArray)
+			{
+				int num = 0;
+				int* v = nullptr;
+				if (CADET_ERR(_pp.getIntArray(_pp.userData, paramName.c_str(), &num, &v)))
+				{
+					if (_pp.getIntArrayItem)
+						return getIntArrayElementwise(paramName);
+					else
+						throw InvalidParameterException("Retrieving int parameter array " + paramName + " failed");
+				}
+
+				LOG(Debug) << "GET array [int] " << paramName << ": " << log::VectorPtr<int>(v, num);
+				return std::vector<int>(v, v + num);
+			}
+
+			return getIntArrayElementwise(paramName);
+		}
+
+		virtual std::vector<uint64_t> getUint64Array(const std::string& paramName)
+		{
+			throw std::logic_error("getUint64Array not implemented");
+		}
+
+		virtual std::vector<bool> getBoolArray(const std::string& paramName)
+		{
+			if (_pp.getBoolArray)
+			{
+				int num = 0;
+				uint8_t* v = nullptr;
+				if (CADET_ERR(_pp.getBoolArray(_pp.userData, paramName.c_str(), &num, &v)))
+				{
+					if (_pp.getBoolArrayItem)
+						return getBoolArrayElementwise(paramName);
+					else
+						throw InvalidParameterException("Retrieving bool parameter array " + paramName + " failed");
+				}
+
+				std::vector<bool> vc(num);
+				for (int i = 0; i < num; ++i)
+					vc[i] = v[i];
+
+				LOG(Debug) << "GET array [bool] " << paramName << ": " << vc;
+				return vc;
+			}
+
+			return getBoolArrayElementwise(paramName);
+		}
+
+		virtual std::vector<std::string> getStringArray(const std::string& paramName)
+		{
+			if (_pp.getStringArray)
+			{
+				int num = 0;
+				char const** v = nullptr;
+				if (CADET_ERR(_pp.getStringArray(_pp.userData, paramName.c_str(), &num, &v)))
+				{
+					if (_pp.getStringArrayItem)
+						return getStringArrayElementwise(paramName);
+					else
+						throw InvalidParameterException("Retrieving string parameter array " + paramName + " failed");
+				}
+
+				std::vector<std::string> vc(num);
+				for (int i = 0; i < num; ++i)
+					vc[i] = v[i];
+
+				LOG(Debug) << "GET array [string] " << paramName << ": " << vc;
+				return vc;
+			}
+
+			return getStringArrayElementwise(paramName);
+		}
+
+		virtual bool exists(const std::string& paramName)
+		{
+			const bool r = _pp.exists(_pp.userData, paramName.c_str()) != 0;
+			LOG(Debug) << "EXISTS " << paramName << ": " << r;
+			return r;
+		}
+
+		virtual bool isArray(const std::string& paramName)
+		{
+			uint8_t res = 0;
+			if (CADET_ERR(_pp.isArray(_pp.userData, paramName.c_str(), &res)))
+				throw InvalidParameterException("Checking whether parameter " + paramName + " is array failed");
+
+			LOG(Debug) << "ISARRAY " << paramName << ": " << (res != 0);
+			return res != 0;
+		}
+
+		virtual std::size_t numElements(const std::string& paramName)
+		{
+			const int num = _pp.numElements(_pp.userData, paramName.c_str());
+			if (num < 0)
+				throw InvalidParameterException("Retrieving string parameter array " + paramName + " failed (does not exist)");
+
+			LOG(Debug) << "NUMELEMENTS " << paramName << ": " << num;
+			return num;
+		}
+
+		virtual void pushScope(const std::string& scope)
+		{
+			if (CADET_ERR(_pp.pushScope(_pp.userData, scope.c_str())))
+				throw InvalidParameterException("Failed to enter scope " + scope);
+
+			LOG(Debug) << "PUSHSCOPE " << scope;
+		}
+
+		virtual void popScope()
+		{
+			if (CADET_ERR(_pp.popScope(_pp.userData)))
+				throw InvalidParameterException("Failed to exit current scope");
+
+			LOG(Debug) << "POPSCOPE";
+		}
+
+	private:
+		const cdtParameterProvider& _pp;
+
+		std::vector<double> getDoubleArrayElementwise(const std::string& paramName)
+		{
+			const int num = _pp.numElements(_pp.userData, paramName.c_str());
+			if (num < 0)
+				throw InvalidParameterException("Retrieving double parameter array " + paramName + " failed (does not exist)");
+
+			if (num == 0)
+				return std::vector<double>(0);
+
+			std::vector<double> v(num);
+			for (int i = 0; i < num; ++i)
+			{
+				if (CADET_ERR(_pp.getDoubleArrayItem(_pp.userData, paramName.c_str(), i, v.data() + i)))
+					throw InvalidParameterException("Retrieving double parameter " + paramName + " failed");
+
+				LOG(Debug) << "GET array (" << i << ") [double] " << paramName << ": " << v[i];
+			}
+
+			return v;
+		}
+
+		std::vector<int> getIntArrayElementwise(const std::string& paramName)
+		{
+			const int num = _pp.numElements(_pp.userData, paramName.c_str());
+			if (num < 0)
+				throw InvalidParameterException("Retrieving int parameter array " + paramName + " failed (does not exist)");
+
+			if (num == 0)
+				return std::vector<int>(0);
+
+			std::vector<int> v(num);
+			for (int i = 0; i < num; ++i)
+			{
+				if (CADET_ERR(_pp.getIntArrayItem(_pp.userData, paramName.c_str(), i, v.data() + i)))
+					throw InvalidParameterException("Retrieving int parameter " + paramName + " failed");
+
+				LOG(Debug) << "GET array (" << i << ") [int] " << paramName << ": " << v[i];
+			}
+
+			return v;
+		}
+
+		std::vector<bool> getBoolArrayElementwise(const std::string& paramName)
+		{
+			const int num = _pp.numElements(_pp.userData, paramName.c_str());
+			if (num < 0)
+				throw InvalidParameterException("Retrieving bool parameter array " + paramName + " failed (does not exist)");
+
+			if (num == 0)
+				return std::vector<bool>(0);
+
+			std::vector<bool> v(num);
+			for (int i = 0; i < num; ++i)
+			{
+				uint8_t temp = 0;
+				if (CADET_ERR(_pp.getBoolArrayItem(_pp.userData, paramName.c_str(), i, &temp)))
+					throw InvalidParameterException("Retrieving bool parameter " + paramName + " failed");
+
+				v[i] = temp;
+				LOG(Debug) << "GET array (" << i << ") [bool] " << paramName << ": " << v[i];
+			}
+
+			return v;
+		}
+
+		std::vector<std::string> getStringArrayElementwise(const std::string& paramName)
+		{
+			const int num = _pp.numElements(_pp.userData, paramName.c_str());
+			if (num < 0)
+				throw InvalidParameterException("Retrieving string parameter array " + paramName + " failed (does not exist)");
+
+			if (num == 0)
+				return std::vector<std::string>(0);
+
+			std::vector<std::string> v(num);
+			for (int i = 0; i < num; ++i)
+			{
+				char const* temp = nullptr;
+				if (CADET_ERR(_pp.getStringArrayItem(_pp.userData, paramName.c_str(), i, &temp)))
+					throw InvalidParameterException("Retrieving string parameter " + paramName + " failed");
+
+				if (!temp)
+					throw InvalidParameterException("Retrieving string parameter " + paramName + " failed (received nullptr)");
+
+				v[i] = temp;
+				LOG(Debug) << "GET array (" << i << ") [string] " << paramName << ": " << v[i];
+			}
+
+			return v;
+		}
+	};
+
+
+	cdtResult runSimulation(cdtDriver* drv, cdtParameterProvider const* paramProvider)
+	{
+		Driver* const realDrv = drv->driver;
+		if (!realDrv)
+			return cdtErrorInvalidInputs;
+		if (!paramProvider)
+			return cdtErrorInvalidInputs;
+
+		try
+		{
+			if (!realDrv->simulator())
+			{
+				CallbackParameterProvider cpp(*paramProvider);
+				realDrv->configure(cpp);
+			}
+			else
+				realDrv->clearResults();
+
+			realDrv->run();
+
+//			cadet::mex::MatlabReaderWriter writer(&output);
+//			drv.write(writer);
+		}
+		catch(const std::exception& e)
+		{
+			LOG(Error) << "Simulation failed: " << e.what();
+			return cdtError;
+		}
+
+		return cdtOK;
+	}
+
+	cdtResult getSolutionOutlet(cdtDriver* drv, int unitOpId, double const** time, double const** data, int* nTime, int* nPort, int* nComp)
+	{
+		Driver* const realDrv = drv->driver;
+		if (!realDrv)
+			return cdtErrorInvalidInputs;
+
+		InternalStorageSystemRecorder* const sysRec = realDrv->solution();
+		if (!sysRec)
+		{
+			LOG(Error) << "System solution recorder not available";
+			return cdtError;
+		}
+
+		if (nTime)
+			*nTime = sysRec->numDataPoints();
+		if (time)
+			*time = sysRec->time();
+
+		InternalStorageUnitOpRecorder* const unitRec = sysRec->unitOperation(unitOpId);
+		if (!unitRec)
+		{
+			LOG(Error) << "Solution recorder for unit ID " << unitOpId << " not found";
+			return cdtErrorInvalidInputs;
+		}
+
+		if (!unitRec->solutionConfig().storeOutlet)
+		{
+			LOG(Error) << "Outlet of unit " << unitOpId << " not recorded";
+			return cdtError;
+		}
+
+		if (nPort)
+			*nPort = unitRec->numOutletPorts();
+		if (nComp)
+			*nComp = unitRec->numComponents();
+		if (data)
+			*data = unitRec->outlet();
+
+		return cdtOK;
+	}
+
+}  // namespace v1
+
+}  // namespace api
+
+}  // namespace cadet
+
+
+extern "C"
+{
+
+	CADET_API cdtResult cdtGetAPIv010000(cdtAPIv010000* ptr)
+	{
+		if (!ptr)
+			return cdtErrorInvalidInputs;
+
+		ptr->createDriver = &cadet::api::v1::createDriver;
+		ptr->deleteDriver = &cadet::api::v1::deleteDriver;
+		ptr->runSimulation = &cadet::api::v1::runSimulation;
+		ptr->getSolutionOutlet = &cadet::api::v1::getSolutionOutlet;
+		return cdtOK;
+	}
+
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,9 @@ target_link_libraries(testLogging PRIVATE CADET::CompileOptions)
 
 
 # CATCH unit tests
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Paths.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/Paths.cpp" @ONLY)
+set(LIBCADET_SHARED_LIBFILE "$<TARGET_FILE:libcadet_shared>")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Paths.cpp.in" "${CMAKE_CURRENT_BINARY_DIR}/Paths.cpp.in" @ONLY)
+file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/Paths_$<CONFIG>.cpp" INPUT "${CMAKE_CURRENT_BINARY_DIR}/Paths.cpp.in")
 
 set(TEST_ADDITIONAL_SOURCES "")
 if (ENABLE_GRM_2D)
@@ -50,7 +52,7 @@ add_executable(testRunner testRunner.cpp JsonTestModels.cpp ColumnTests.cpp Unit
 	ParamDepTests.cpp ParameterDependencies.cpp
 	ModelSystem.cpp
 	BandMatrix.cpp DenseMatrix.cpp SparseMatrix.cpp StringHashing.cpp LogUtils.cpp AD.cpp Subset.cpp Graph.cpp
-	"${CMAKE_CURRENT_BINARY_DIR}/Paths.cpp" "${CMAKE_SOURCE_DIR}/src/io/JsonParameterProvider.cpp"
+	"${CMAKE_CURRENT_BINARY_DIR}/Paths_$<CONFIG>.cpp" "${CMAKE_SOURCE_DIR}/src/io/JsonParameterProvider.cpp"
 	${TEST_ADDITIONAL_SOURCES}
 	$<TARGET_OBJECTS:libcadet_object>)
 
@@ -90,6 +92,12 @@ endforeach()
 foreach(_TARGET IN LISTS TEST_NONLINALG_TARGETS)
 	target_link_libraries(${_TARGET} PRIVATE libcadet_nonlinalg_static)
 endforeach()
+
+# ---------------------------------------------------
+
+
+add_executable(testCAPIv1 "${CMAKE_CURRENT_BINARY_DIR}/Paths_$<CONFIG>.cpp" testCAPIv1.cpp)
+target_include_directories(testCAPIv1 PRIVATE ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/ThirdParty/json)
 
 # ---------------------------------------------------
 

--- a/test/Paths.cpp.in
+++ b/test/Paths.cpp.in
@@ -14,3 +14,8 @@ const char* getTestDirectory()
 {
 	return "@CMAKE_SOURCE_DIR@/test";
 }
+
+const char* getLibBinaryPath()
+{
+	return "$<TARGET_FILE:libcadet_shared>";
+}

--- a/test/testCAPIv1.cpp
+++ b/test/testCAPIv1.cpp
@@ -1,0 +1,787 @@
+#include <stdexcept>
+#include <stdint.h>
+#include <windows.h>
+#include <iostream>
+#include <memory>
+#include <functional>
+#include <vector>
+#include <stack>
+#include <string>
+
+#include <json.hpp>
+using json = nlohmann::json;
+
+#include "cadet/cadet.h"
+
+const char* getLibBinaryPath();
+
+typedef cdtResult (*cdtGetAPIv010000_t)(cdtAPIv010000* ptr);
+
+typedef void (*cdtSetLogReceiver_t)(cdtLogHandler recv);
+typedef void (*cdtSetLogLevel_t)(int lvl);
+
+void logHandler(const char* file, const char* func, const unsigned int line, int lvl, const char* lvlStr, const char* message)
+{
+	std::cout << lvlStr << " [" << func << ":" << line << "] " << message << std::endl;
+}
+
+class LibLoader
+{
+public:
+	LibLoader(char const* path) : _hdLib(0)
+	{
+		_hdLib = LoadLibrary(path);
+		if (_hdLib)
+			std::cout << "Loaded library " << path << std::endl;
+	}
+
+	~LibLoader()
+	{
+		if (_hdLib)
+		{
+			FreeLibrary(_hdLib);
+			std::cout << "Deleted library" << std::endl;
+		}
+	}
+
+	bool isValid() { return _hdLib; }
+
+	template <typename T> T load(char const* func)
+	{
+		return reinterpret_cast<T>(GetProcAddress(_hdLib, func));
+	}
+
+private:
+	HINSTANCE _hdLib;
+};
+
+
+json createColumnWithSMAJson(const std::string& uoType)
+{
+	json config;
+	config["UNIT_TYPE"] = uoType;
+	config["NCOMP"] = 4;
+	config["VELOCITY"] = 5.75e-4;
+	config["COL_DISPERSION"] = 5.75e-8;
+	config["COL_DISPERSION_RADIAL"] = 1e-6;
+	config["FILM_DIFFUSION"] = {6.9e-6, 6.9e-6, 6.9e-6, 6.9e-6};
+	config["PAR_DIFFUSION"] = {7e-10, 6.07e-11, 6.07e-11, 6.07e-11};
+	config["PAR_SURFDIFFUSION"] = {0.0, 0.0, 0.0, 0.0};
+
+	// Geometry
+	config["COL_LENGTH"] = 0.014;
+	config["COL_RADIUS"] = 0.01;
+	config["PAR_RADIUS"] = 4.5e-5;
+	config["COL_POROSITY"] = 0.37;
+	config["PAR_POROSITY"] = 0.75;
+	config["TOTAL_POROSITY"] = 0.37 + (1.0 - 0.37) * 0.75;
+
+	// Initial conditions
+	config["INIT_C"] = {50.0, 0.0, 0.0, 0.0};
+	config["INIT_Q"] = {1.2e3, 0.0, 0.0, 0.0};
+
+	// Adsorption
+	config["ADSORPTION_MODEL"] = std::string("STERIC_MASS_ACTION");
+	{
+		json ads;
+		ads["IS_KINETIC"] = 1;
+		ads["SMA_LAMBDA"] = 1.2e3;
+		ads["SMA_KA"] = {0.0, 35.5, 1.59, 7.7};
+		ads["SMA_KD"] = {0.0, 1000.0, 1000.0, 1000.0};
+		ads["SMA_NU"] = {0.0, 4.7, 5.29, 3.7};
+		ads["SMA_SIGMA"] = {0.0, 11.83, 10.6, 10.0};
+		config["adsorption"] = ads;
+	}
+
+	// Discretization
+	{
+		json disc;
+
+		disc["NCOL"] = 16;
+		disc["NPAR"] = 4;
+		disc["NBOUND"] = {1, 1, 1, 1};
+
+		if (uoType == "GENERAL_RATE_MODEL_2D")
+		{
+			disc["NCOL"] = 8;
+			disc["NRAD"] = 3;
+			disc["NPAR"] = 3;
+			disc["RADIAL_DISC_TYPE"] = "EQUIDISTANT";
+		}
+
+		disc["PAR_DISC_TYPE"] = std::string("EQUIDISTANT_PAR");
+
+		disc["USE_ANALYTIC_JACOBIAN"] = true;
+		disc["MAX_KRYLOV"] = 0;
+		disc["GS_TYPE"] = 1;
+		disc["MAX_RESTARTS"] = 10;
+		disc["SCHUR_SAFETY"] = 1e-8;
+
+		// WENO
+		{
+			json weno;
+
+			weno["WENO_ORDER"] = 3;
+			weno["BOUNDARY_MODEL"] = 0;
+			weno["WENO_EPS"] = 1e-10;
+			disc["weno"] = weno;
+		}
+		config["discretization"] = disc;
+	}
+
+	return config;
+}
+
+json createLWEJson(const std::string& uoType)
+{
+	json config;
+	// Model
+	{
+		json model;
+		model["NUNITS"] = 2;
+		model["unit_000"] = createColumnWithSMAJson(uoType);
+
+		// Inlet - unit 001
+		{
+			json inlet;
+
+			inlet["UNIT_TYPE"] = std::string("INLET");
+			inlet["INLET_TYPE"] = std::string("PIECEWISE_CUBIC_POLY");
+			inlet["NCOMP"] = 4;
+
+			{
+				json sec;
+
+				sec["CONST_COEFF"] = {50.0, 1.0, 1.0, 1.0};
+				sec["LIN_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+				sec["QUAD_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+				sec["CUBE_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+
+				inlet["sec_000"] = sec;
+			}
+
+			{
+				json sec;
+
+				sec["CONST_COEFF"] = {50.0, 0.0, 0.0, 0.0};
+				sec["LIN_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+				sec["QUAD_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+				sec["CUBE_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+
+				inlet["sec_001"] = sec;
+			}
+
+			{
+				json sec;
+
+				sec["CONST_COEFF"] = {100.0, 0.0, 0.0, 0.0};
+				sec["LIN_COEFF"] = {0.2, 0.0, 0.0, 0.0};
+				sec["QUAD_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+				sec["CUBE_COEFF"] = {0.0, 0.0, 0.0, 0.0};
+
+				inlet["sec_002"] = sec;
+			}
+
+			model["unit_001"] = inlet;
+		}
+
+		// Valve switches
+		{
+			json con;
+			con["NSWITCHES"] = 1;
+			con["CONNECTIONS_INCLUDE_PORTS"] = true;
+
+			{
+				json sw;
+
+				// This switch occurs at beginning of section 0 (initial configuration)
+				sw["SECTION"] = 0;
+
+				if (uoType == "GENERAL_RATE_MODEL_2D")
+				{
+					// Connection list is 3x7 since we have 1 connection between
+					// the two unit operations with 3 ports (and we need to have 7 columns)
+					sw["CONNECTIONS"] = {1.0, 0.0, 0.0, 0.0, -1.0, -1.0, 7.42637597e-09,
+					                     1.0, 0.0, 0.0, 1.0, -1.0, -1.0, 2.22791279e-08,
+					                     1.0, 0.0, 0.0, 2.0, -1.0, -1.0, 3.71318798e-08};
+					// Connections: From unit operation 1 port 0
+					//              to unit operation 0 port 0,
+					//              connect component -1 (i.e., all components)
+					//              to component -1 (i.e., all components) with
+					//              volumetric flow rate 7.42637597e-09 m^3/s
+				}
+				else
+				{
+					// Connection list is 1x7 since we have 1 connection between
+					// the two unit operations (and we need to have 7 columns)
+					sw["CONNECTIONS"] = {1.0, 0.0, -1.0, -1.0, -1.0, -1.0, 1.0};
+					// Connections: From unit operation 1 port -1 (i.e., all ports) 
+					//              to unit operation 0 port -1 (i.e., all ports),
+					//              connect component -1 (i.e., all components)
+					//              to component -1 (i.e., all components) with
+					//              volumetric flow rate 1.0 m^3/s
+				}
+
+				con["switch_000"] = sw;
+			}
+			model["connections"] = con;
+		}
+
+		// Solver settings
+		{
+			json solver;
+
+			solver["MAX_KRYLOV"] = 0;
+			solver["GS_TYPE"] = 1;
+			solver["MAX_RESTARTS"] = 10;
+			solver["SCHUR_SAFETY"] = 1e-8;
+			model["solver"] = solver;
+		}
+
+		config["model"] = model;
+	}
+
+	// Return
+	{
+		json ret;
+		ret["WRITE_SOLUTION_TIMES"] = true;
+	
+		json grm;
+		grm["WRITE_SOLUTION_BULK"] = false;
+		grm["WRITE_SOLUTION_PARTICLE"] = false;
+		grm["WRITE_SOLUTION_FLUX"] = false;
+		grm["WRITE_SOLUTION_INLET"] = true;
+		grm["WRITE_SOLUTION_OUTLET"] = true;
+		
+		ret["unit_000"] = grm;
+		config["return"] = ret;
+	}
+
+	// Solver
+	{
+		json solver;
+
+		{
+			std::vector<double> solTimes;
+
+			if (uoType == "LUMPED_RATE_MODEL_WITHOUT_PORES")
+			{
+				// Lumped rate model without pores has less rate limiting
+				// Thus, a shorter simulation time suffices
+				solTimes.reserve(1101);
+				for (double t = 0.0; t <= 1100.0; t += 1.0)
+					solTimes.push_back(t);
+			}
+			else
+			{
+				solTimes.reserve(1501);
+				for (double t = 0.0; t <= 1500.0; t += 1.0)
+					solTimes.push_back(t);
+			}
+
+			solver["USER_SOLUTION_TIMES"] = solTimes;
+		}
+
+		solver["NTHREADS"] = 1;
+
+		// Sections
+		{
+			json sec;
+
+			sec["NSEC"] = 3;
+			if (uoType == "LUMPED_RATE_MODEL_WITHOUT_PORES")
+				sec["SECTION_TIMES"] = {0.0, 10.0, 90.0, 1100.0};
+			else
+				sec["SECTION_TIMES"] = {0.0, 10.0, 90.0, 1500.0};
+			sec["SECTION_CONTINUITY"] = {false, false};
+
+			solver["sections"] = sec;
+		}
+
+		// Time integrator
+		{
+			json ti;
+
+			ti["ABSTOL"] = 1e-8;
+			ti["RELTOL"] = 1e-6;
+			ti["ALGTOL"] = 1e-12;
+			ti["INIT_STEP_SIZE"] = 1e-6;
+			ti["MAX_STEPS"] = 10000;
+			ti["MAX_STEP_SIZE"] = 0.0;
+			ti["RELTOL_SENS"] = 1e-6;
+			ti["ERRORTEST_SENS"] = true;
+			ti["MAX_NEWTON_ITER"] = 3;
+			ti["MAX_ERRTEST_FAIL"] = 7;
+			ti["MAX_CONVTEST_FAIL"] = 10;
+			ti["MAX_NEWTON_ITER_SENS"] = 3;
+			ti["CONSISTENT_INIT_MODE"] = 1;
+			ti["CONSISTENT_INIT_MODE_SENS"] = 1;
+
+			solver["time_integrator"] = ti;
+		}
+
+		config["solver"] = solver;
+	}
+	return config;
+}
+
+
+class JsonNavigator
+{
+public:
+	JsonNavigator(const json& root) : _root(root), _scopePath("/")
+	{
+		_opened.push(&_root);
+	}
+	~JsonNavigator() { }
+
+	void pushScope(const std::string& scope)
+	{
+		std::cout << "[PP] SCOPE " << scope << "\n";
+		_opened.push(&_opened.top()->at(scope));
+		_scopePath += "/" + scope;
+	}
+
+	void popScope()
+	{
+		std::cout << "[PP] SCOPE POP\n";
+		_opened.pop();
+
+		std::size_t lastIdx = std::string::npos;
+		if (_scopePath.back() == '/')
+			lastIdx = _scopePath.length() - 2;
+
+		const std::size_t idx = _scopePath.find_last_of('/', lastIdx);
+		_scopePath.erase(idx);
+	}
+
+	const json& current() const { return *_opened.top(); }
+
+private:
+	const json& _root;
+	std::stack<json const*> _opened;
+	std::string _scopePath;
+};
+
+cdtResult getDouble(void* userData, const char* paramName, double* val)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		const json& p = jn.current().at(paramName);
+		const json& pp = (p.is_array() && (p.size() == 1)) ? p[0] : p;
+
+		std::cout << "[PP] GET scalar [double] " << paramName << " = " << pp.get<double>() << "\n";
+		*val = pp.get<double>();
+		return cdtOK;
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] GET scalar [double] ERROR: " << e.what() << std::endl;
+		return cdtError;
+	}
+}
+
+cdtResult getInt(void* userData, const char* paramName, int* val)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		const json& p = jn.current().at(paramName);
+		const json& pp = (p.is_array() && (p.size() == 1)) ? p[0] : p;
+
+		if (pp.is_boolean())
+		{
+			std::cout << "[PP] GET scalar [int] " << paramName << " = " << static_cast<int>(pp.get<bool>()) << "\n";
+			*val = pp.get<bool>();
+		}
+		else
+		{
+			std::cout << "[PP] GET scalar [int] " << paramName << " = " << pp.get<int>() << "\n";
+			*val = pp.get<int>();
+		}
+		return cdtOK;
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] GET scalar [int] ERROR: " << e.what() << std::endl;
+		return cdtError;
+	}
+}
+
+cdtResult getBool(void* userData, const char* paramName, uint8_t* val)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		const json& p = jn.current().at(paramName);
+		const json& pp = (p.is_array() && (p.size() == 1)) ? p[0] : p;
+
+		if (pp.is_number_integer())
+		{
+			std::cout << "[PP] GET scalar [bool] " << paramName << " = " << static_cast<bool>(pp.get<int>()) << "\n";
+			*val = static_cast<bool>(pp.get<int>());
+		}
+		else
+		{
+			std::cout << "[PP] GET scalar [bool] " << paramName << " = " << pp.get<bool>() << "\n";
+			*val = pp.get<bool>();
+		}
+		return cdtOK;
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] GET scalar [bool] ERROR: " << e.what() << std::endl;
+		return cdtError;
+	}
+}
+
+cdtResult getString(void* userData, const char* paramName, char const** val)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		const json& p = jn.current().at(paramName);
+		const json& pp = (p.is_array() && (p.size() == 1)) ? p[0] : p;
+
+		std::cout << "[PP] GET scalar [string] " << paramName << " = " << pp.get_ref<const std::string&>() << "\n";
+		*val = pp.get_ptr<const std::string*>()->c_str();
+		return cdtOK;
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] GET scalar [string] ERROR: " << e.what() << std::endl;
+		return cdtError;
+	}
+}
+
+cdtResult getDoubleArrayItem(void* userData, const char* paramName, int idx, double* val)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		const json& p = jn.current().at(paramName);
+
+		if ((idx == 0) && !p.is_array())
+		{
+			std::cout << "[PP] GET array (" << idx << ") [double] " << paramName << " = " << p.get<double>() << "\n";
+			*val = p.get<double>();
+			return cdtOK;
+		}
+		if ((idx > 0) && !p.is_array())
+		{
+			std::cout << "[PP] GET array (" << idx << ") [double] ERROR: Item is scalar instead of array" << std::endl;
+			return cdtError;
+		}
+		if ((idx > 0) && (idx >= p.size()))
+		{
+			std::cout << "[PP] GET array (" << idx << ") [double] ERROR: Index out of bounds (size is " << p.size() << ")" << std::endl;
+			return cdtError;
+		}
+
+		const json& pp = p[idx];
+
+		std::cout << "[PP] GET array (" << idx << ") [double] " << paramName << " = " << pp.get<double>() << "\n";
+		*val = pp.get<double>();
+		return cdtOK;
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] GET array (" << idx << ") [double] ERROR: " << e.what() << std::endl;
+		return cdtError;
+	}
+}
+
+cdtResult getIntArrayItem(void* userData, const char* paramName, int idx, int* val)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		const json& p = jn.current().at(paramName);
+
+		if ((idx == 0) && !p.is_array())
+		{
+			std::cout << "[PP] GET array (" << idx << ") [int] " << paramName << " = " << p.get<int>() << "\n";
+			*val = p.get<int>();
+			return cdtOK;
+		}
+		if ((idx > 0) && !p.is_array())
+		{
+			std::cout << "[PP] GET array (" << idx << ") [int] ERROR: Item is scalar instead of array" << std::endl;
+			return cdtError;
+		}
+		if ((idx > 0) && (idx >= p.size()))
+		{
+			std::cout << "[PP] GET array (" << idx << ") [int] ERROR: Index out of bounds (size is " << p.size() << ")" << std::endl;
+			return cdtError;
+		}
+
+		const json& pp = p[idx];
+
+		if (pp.is_boolean())
+		{
+			std::cout << "[PP] GET array (" << idx << ") [int] " << paramName << " = " << static_cast<int>(pp.get<bool>()) << "\n";
+			*val = pp.get<bool>();
+		}
+		else
+		{
+			std::cout << "[PP] GET array (" << idx << ") [int] " << paramName << " = " << pp.get<int>() << "\n";
+			*val = pp.get<int>();
+		}
+		return cdtOK;
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] GET array (" << idx << ") [int] ERROR: " << e.what() << std::endl;
+		return cdtError;
+	}
+}
+
+cdtResult getBoolArrayItem(void* userData, const char* paramName, int idx, uint8_t* val)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		const json& p = jn.current().at(paramName);
+
+		if ((idx == 0) && !p.is_array())
+		{
+			std::cout << "[PP] GET array (" << idx << ") [bool] " << paramName << " = " << p.get<bool>() << "\n";
+			*val = p.get<bool>();
+			return cdtOK;
+		}
+		if ((idx > 0) && !p.is_array())
+		{
+			std::cout << "[PP] GET array (" << idx << ") [bool] ERROR: Item is scalar instead of array" << std::endl;
+			return cdtError;
+		}
+		if ((idx > 0) && (idx >= p.size()))
+		{
+			std::cout << "[PP] GET array (" << idx << ") [bool] ERROR: Index out of bounds (size is " << p.size() << ")" << std::endl;
+			return cdtError;
+		}
+
+		const json& pp = p[idx];
+
+		if (pp.is_number_integer())
+		{
+			std::cout << "[PP] GET array (" << idx << ") [bool] " << paramName << " = " << static_cast<bool>(pp.get<int>()) << "\n";
+			*val = static_cast<bool>(pp.get<int>());
+		}
+		else
+		{
+			std::cout << "[PP] GET array (" << idx << ") [bool] " << paramName << " = " << pp.get<bool>() << "\n";
+			*val = pp.get<bool>();
+		}
+		return cdtOK;
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] GET array (" << idx << ") [bool] ERROR: " << e.what() << std::endl;
+		return cdtError;
+	}
+}
+
+cdtResult getStringArrayItem(void* userData, const char* paramName, int idx, char const** val)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		const json& p = jn.current().at(paramName);
+
+		if ((idx == 0) && !p.is_array())
+		{
+			std::cout << "[PP] GET array (" << idx << ") [string] " << paramName << " = " << p.get_ref<const std::string&>() << "\n";
+			*val = p.get_ptr<const std::string*>()->c_str();
+			return cdtOK;
+		}
+		if ((idx > 0) && !p.is_array())
+		{
+			std::cout << "[PP] GET array (" << idx << ") [string] ERROR: Item is scalar instead of array" << std::endl;
+			return cdtError;
+		}
+		if ((idx > 0) && (idx >= p.size()))
+		{
+			std::cout << "[PP] GET array (" << idx << ") [string] ERROR: Index out of bounds (size is " << p.size() << ")" << std::endl;
+			return cdtError;
+		}
+
+		const json& pp = p[idx];
+
+		std::cout << "[PP] GET array (" << idx << ") [string] " << paramName << " = " << pp.get_ref<const std::string&>() << "\n";
+		*val = pp.get_ptr<const std::string*>()->c_str();
+		return cdtOK;
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] GET array (" << idx << ") [string] ERROR: " << e.what() << std::endl;
+		return cdtError;
+	}
+}
+
+int exists(void* userData, const char* elemName)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	const json& p = jn.current();
+	const bool found = p.find(elemName) != p.end();
+
+	std::cout << "[PP] EXISTS " << elemName << " = " << (found ? "yes" : "no") << "\n";
+	return found;
+}
+
+cdtResult isArray(void* userData, const char* paramName, uint8_t* res)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		const json& p = jn.current().at(paramName);
+
+		if (p.is_array())
+			*res = 1;
+		else
+			*res = 0;
+
+		std::cout << "[PP] ISARRAY " << paramName << " = " << p.is_array() << "\n";
+		return cdtOK;
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] ISARRAY ERROR: " << e.what() << std::endl;
+		return cdtError;
+	}
+}
+
+int numElements(void* userData, const char* paramName)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		const json& p = jn.current().at(paramName);
+		std::cout << "[PP] NUMELEMENTS " << paramName << " = " << p.size() << "\n";
+		return p.size();
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] NUMELEMENTS ERROR: " << e.what() << std::endl;
+		return -1;
+	}
+}
+
+cdtResult pushScope(void* userData, const char* scope)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	try
+	{
+		jn.pushScope(scope);
+		return cdtOK;
+	}
+	catch(const std::exception& e)
+	{
+		std::cout << "[PP] PUSHSCOPE ERROR: " << e.what() << std::endl;
+		return cdtError;
+	}
+}
+
+cdtResult popScope(void* userData)
+{
+	JsonNavigator& jn = *static_cast<JsonNavigator*>(userData);
+	jn.popScope();
+	return cdtOK;
+}
+
+
+int main(int argc, char** argv)
+{
+	LibLoader loader(getLibBinaryPath());
+
+	if (!loader.isValid())
+	{
+		std::cout << "Failed to load DLL" << std::endl;
+		return 1;
+	}
+
+	const cdtSetLogReceiver_t setLogReceiver = loader.load<cdtSetLogReceiver_t>("cdtSetLogReceiver");
+	if (!setLogReceiver)
+	{
+		std::cout << "Failed to load cdtSetLogReceiver() function" << std::endl;
+		return 1;
+	}
+	setLogReceiver(&logHandler);
+
+	const cdtSetLogLevel_t setLogLevel = loader.load<cdtSetLogLevel_t>("cdtSetLogLevel");
+	if (!setLogLevel)
+	{
+		std::cout << "Failed to load cdtSetLogLevel() function" << std::endl;
+		return 1;
+	}
+	setLogLevel(cdtLogLevelTrace);
+
+	const cdtGetAPIv010000_t apiLoader = loader.load<cdtGetAPIv010000_t>("cdtGetAPIv010000");
+	if (!apiLoader)
+	{
+		std::cout << "Failed to load cdtGetAPIv010000() function" << std::endl;
+		return 1;
+	}
+
+	cdtAPIv010000 api;
+	const cdtResult resApiLoad = apiLoader(&api);
+
+	std::cout << "cdtGetAPIv010000() = " << resApiLoad << " api.createDriver = " << api.createDriver << std::endl;
+	if (CADET_ERR(resApiLoad))
+	{
+		std::cout << "Error obtaining API loader" << std::endl;
+		return 1;
+	}
+
+	std::unique_ptr<cdtDriver, std::function<void(cdtDriver*)>> drv(api.createDriver(), [&api](cdtDriver* ptr)
+		{
+			api.deleteDriver(ptr);
+			std::cout << "Delete driver" << std::endl;
+		}
+	);
+
+	const json simSpec = createLWEJson("GENERAL_RATE_MODEL");
+	JsonNavigator jn(simSpec);
+
+	cdtParameterProvider pp
+	{
+		&jn,
+		&getDouble,
+		&getInt,
+		&getBool,
+		&getString,
+		nullptr,
+		nullptr,
+		nullptr,
+		nullptr,
+		&getDoubleArrayItem,
+		&getIntArrayItem,
+		&getBoolArrayItem,
+		&getStringArrayItem,
+		&exists,
+		&isArray,
+		&numElements,
+		&pushScope,
+		&popScope
+	};
+
+	const cdtResult resSim = api.runSimulation(drv.get(), &pp);
+	std::cout << "runSimulation() = " << resSim << std::endl;
+
+	if (CADET_ERR(resSim))
+	{
+		std::cout << "Simulation failed" << std::endl;
+		return 1;
+	}
+
+	double const* time = nullptr;
+	double const* outlet = nullptr;
+	int nTime = 0;
+	int nPort = 0;
+	int nComp = 0;
+	const cdtResult resSol = api.getSolutionOutlet(drv.get(), 0, &time, &outlet, &nTime, &nPort, &nComp);
+
+	std::cout << "getSolutionOutlet() = " << resSol << " nTime = " << nTime << " nPort = " << nPort << " nComp = " << nComp << std::endl;
+
+	return 0;
+}


### PR DESCRIPTION
Adds a simple C interface to libcadet. The parameter provider interface
is realized by callback functions. A simulation can be performed and
the solution at the outlet of the unit operations can be queried.

Also includes a test application that dynamically loads the library at
runtime (only Windows) and executes a simulation specified in JSON
format internally.

This commit provides the first steps regarding #16 and, thus, #12.