### PR TITLE
Add separate reference concentration for pH dependent terms in Generalized Ion Exchange adsorption model

### DIFF
--- a/doc/tex/docs/binding.tex
+++ b/doc/tex/docs/binding.tex
@@ -357,7 +357,7 @@ In addition to the first component $c_{p,0}$, which represents salt, the second 
 In comparison to the SMA model, the characteristic charge $\nu$ and the adsorption and desorption rate constants are modified:
 \begin{align*}
   \nu_0 q_0 &= \Lambda - \sum_{j=2}^{N_{\text{comp}} - 1} \nu_j(c_{p,1}) q_j \\
-  \frac{\partial q_i}{\partial t} &= k_{a,i}(c_{p,0},c_{p,1}) \: c_{p,i} \: \left( \frac{\bar{q}_0 }{q_{\text{ref}}} \right)^{\frac{\nu_i(c_{p,1})}{\nu_0}} - k_{d,i}(c_{p,0},c_{p,1}) \: q_i \: \left( \frac{c_{p,0}}{c_{\text{ref}}} \right)^{\frac{\nu_i(c_{p,1})}{\nu_0}} & &i = 2, \dots, N_{\text{comp}} - 1,
+  \frac{\partial q_i}{\partial t} &= k_{a,i}(c_{p,0},c_{p,1}) \: c_{p,i} \: \frac{ \left( \bar{q}_0 \right)^{\frac{\nu_i(c_{p,1})}{\nu_0}} }{ \left(q_{\text{ref}} \right)^{\frac{\nu_{i,\mathrm{base}}}{\nu_0}} } - k_{d,i}(c_{p,0},c_{p,1}) \: q_i \: \frac{\left( c_{p,0} \right)^{\frac{\nu_i(c_{p,1})}{\nu_0}} }{\left( c_{\text{ref}} \right)^{\frac{\nu_{i,\mathrm{base}}}{\nu_0}}} & &i = 2, \dots, N_{\text{comp}} - 1,
 \end{align*}
 where
 \begin{align*}

--- a/src/libcadet/model/Parameters.hpp
+++ b/src/libcadet/model/Parameters.hpp
@@ -501,6 +501,12 @@ public:
 	 */
 	inline std::size_t size() const CADET_NOEXCEPT { return 1; }
 
+	inline const active& getC() const CADET_NOEXCEPT { return *_refC; }
+	inline active& getC() CADET_NOEXCEPT { return *_refC; }
+
+	inline const active& getQ() const CADET_NOEXCEPT { return *_refQ; }
+	inline active& getQ() CADET_NOEXCEPT { return *_refQ; }
+
 protected:
 	active* _refC; //!< Reference liquid phase concentration
 	active* _refQ; //!< Reference solid phase concentration

--- a/src/libcadet/model/binding/BiStericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/BiStericMassActionBinding.cpp
@@ -39,7 +39,7 @@
 		],
 	"constantParameters":
 		[
-			{ "type": "ReferenceConcentrationBoundStateDependentParameter", "varName": ["refC0", "refQ"], "objName": "_refConcentration", "confPrefix": "BISMA_"}
+			{ "type": "ReferenceConcentrationBoundStateDependentParameter", "varName": ["refC0", "refQ"], "objName": "refConcentration", "confPrefix": "BISMA_"}
 		]
 }
 </codegen>*/

--- a/src/libcadet/model/binding/ExternalFunctionTemplate.cpp
+++ b/src/libcadet/model/binding/ExternalFunctionTemplate.cpp
@@ -86,14 +86,18 @@ public:
 	inline bool configure(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
 	{
 {% for p in parameters %}
+	{% if not existsIn(p, "skipConfig") %}
 		_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+	{% endif %}
 {% endfor %}
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
-		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.configure("{{ p/confPrefix }}", paramProvider, nComp, nBoundStates);
-		{% else %}
-			_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+		{% if not existsIn(p, "skipConfig") %}
+			{% if length(p/varName) > 1 %}
+				_{{ p/objName }}.configure("{{ p/confPrefix }}", paramProvider, nComp, nBoundStates);
+			{% else %}
+				_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+			{% endif %}
 		{% endif %}
 	{% endfor %}
 {% endif %}
@@ -248,14 +252,18 @@ public:
 	inline bool configure(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBoundStates)
 	{
 {% for p in parameters %}
+	{% if not existsIn(p, "skipConfig") %}
 		_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+	{% endif %}
 {% endfor %}
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
-		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.configure("{{ p/confPrefix }}", paramProvider, nComp, nBoundStates);
-		{% else %}
-			_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+		{% if not existsIn(p, "skipConfig") %}
+			{% if length(p/varName) > 1 %}
+				_{{ p/objName }}.configure("{{ p/confPrefix }}", paramProvider, nComp, nBoundStates);
+			{% else %}
+				_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+			{% endif %}
 		{% endif %}
 	{% endfor %}
 {% endif %}

--- a/src/libcadet/model/binding/ExternalFunctionTemplate.cpp
+++ b/src/libcadet/model/binding/ExternalFunctionTemplate.cpp
@@ -74,7 +74,7 @@ public:
 		,
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}({% for v in p/varName %} &_localParams.{{ v }} {% if not is_last %},{% endif %} {% endfor %})
+			_{{ p/objName }}({% for v in p/varName %} &_localParams.{{ v }} {% if not is_last %},{% endif %} {% endfor %})
 		{% else %}
 			_{{ p/varName }}(&_localParams.{{ p/varName }})
 		{% endif %}
@@ -112,7 +112,7 @@ public:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.registerParam("{{ p/confPrefix }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
+			_{{ p/objName }}.registerParam("{{ p/confPrefix }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
 		{% else %}
 			_{{ p/varName }}.registerParam("{{ p/confName }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
 		{% endif %}
@@ -128,7 +128,7 @@ public:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.reserve(numElem, numSlices, nComp, nBoundStates);
+			_{{ p/objName }}.reserve(numElem, numSlices, nComp, nBoundStates);
 		{% else %}
 			_{{ p/varName }}.reserve(numElem, numSlices, nComp, nBoundStates);
 		{% endif %}
@@ -155,9 +155,14 @@ public:
 		{% if length(p/varName) == 1 %}
 			inline const {{ p/type }}& {{ p/varName }}() const CADET_NOEXCEPT { return _{{ p/varName }}; }
 			inline {{ p/type }}& {{ p/varName }}() CADET_NOEXCEPT { return _{{ p/varName }}; }
+		{% else %}
+			inline const {{ p/type }}& {{ p/objName }}() const CADET_NOEXCEPT { return _{{ p/objName }}; }
+			inline {{ p/type }}& {{ p/objName }}() CADET_NOEXCEPT { return _{{ p/objName }}; }
 		{% endif %}
 	{% endfor %}
 {% endif %}
+
+	inline char const* prefixInConfiguration() const CADET_NOEXCEPT { return ""; }
 
 protected:
 	inline bool validateConfig(unsigned int nComp, unsigned int const* nBoundStates);
@@ -170,7 +175,7 @@ protected:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/type }} {{ p/objName }};
+			{{ p/type }} _{{ p/objName }};
 		{% else %}
 			{{ p/type }} _{{ p/varName }};
 		{% endif %}
@@ -240,7 +245,7 @@ public:
 		:
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}({% for v in p/varName %} &_constParams.{{ v }} {% if not is_last %},{% endif %} {% endfor %})
+			_{{ p/objName }}({% for v in p/varName %} &_constParams.{{ v }} {% if not is_last %},{% endif %} {% endfor %})
 		{% else %}
 			_{{ p/varName }}(&_constParams.{{ p/varName }})
 		{% endif %}
@@ -279,7 +284,7 @@ public:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.registerParam("{{ p/confPrefix }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
+			_{{ p/objName }}.registerParam("{{ p/confPrefix }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
 		{% else %}
 			_{{ p/varName }}.registerParam("{{ p/confName }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
 		{% endif %}
@@ -295,7 +300,7 @@ public:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.reserve(numElem, numSlices, nComp, nBoundStates);
+			_{{ p/objName }}.reserve(numElem, numSlices, nComp, nBoundStates);
 		{% else %}
 			_{{ p/varName }}.reserve(numElem, numSlices, nComp, nBoundStates);
 		{% endif %}
@@ -380,9 +385,14 @@ public:
 		{% if length(p/varName) == 1 %}
 			inline const {{ p/type }}& {{ p/varName }}() const CADET_NOEXCEPT { return _{{ p/varName }}; }
 			inline {{ p/type }}& {{ p/varName }}() CADET_NOEXCEPT { return _{{ p/varName }}; }
+		{% else %}
+			inline const {{ p/type }}& {{ p/objName }}() const CADET_NOEXCEPT { return _{{ p/objName }}; }
+			inline {{ p/type }}& {{ p/objName }}() CADET_NOEXCEPT { return _{{ p/objName }}; }
 		{% endif %}
 	{% endfor %}
 {% endif %}
+
+	inline char const* prefixInConfiguration() const CADET_NOEXCEPT { return "EXT_"; }
 
 protected:
 	inline bool validateConfig(unsigned int nComp, unsigned int const* nBoundStates);
@@ -395,7 +405,7 @@ protected:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/type }} {{ p/objName }};
+			{{ p/type }} _{{ p/objName }};
 		{% else %}
 			{{ p/type }} _{{ p/varName }};
 		{% endif %}

--- a/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
+++ b/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
@@ -49,7 +49,7 @@
 		],
 	"constantParameters":
 		[
-			{ "type": "ReferenceConcentrationParameter", "varName": ["refC0", "refQ"], "objName": "_refConcentration", "confPrefix": "GIEX_"}
+			{ "type": "ReferenceConcentrationParameter", "varName": ["refC0", "refQ"], "objName": "refConcentration", "confPrefix": "GIEX_"}
 		]
 }
 </codegen>*/

--- a/src/libcadet/model/binding/MultiStateStericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/MultiStateStericMassActionBinding.cpp
@@ -40,7 +40,7 @@
 		],
 	"constantParameters":
 		[
-			{ "type": "ReferenceConcentrationParameter", "varName": ["refC0", "refQ"], "objName": "_refConcentration", "confPrefix": "MSSMA_"}
+			{ "type": "ReferenceConcentrationParameter", "varName": ["refC0", "refQ"], "objName": "refConcentration", "confPrefix": "MSSMA_"}
 		]
 }
 </codegen>*/

--- a/src/libcadet/model/binding/SelfAssociationBinding.cpp
+++ b/src/libcadet/model/binding/SelfAssociationBinding.cpp
@@ -40,7 +40,7 @@
 		],
 	"constantParameters":
 		[
-			{ "type": "ReferenceConcentrationParameter", "varName": ["refC0", "refQ"], "objName": "_refConcentration", "confPrefix": "SAI_"}
+			{ "type": "ReferenceConcentrationParameter", "varName": ["refC0", "refQ"], "objName": "refConcentration", "confPrefix": "SAI_"}
 		]
 }
 </codegen>*/

--- a/src/libcadet/model/binding/StericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/StericMassActionBinding.cpp
@@ -39,7 +39,7 @@
 		],
 	"constantParameters":
 		[
-			{ "type": "ReferenceConcentrationParameter", "varName": ["refC0", "refQ"], "objName": "_refConcentration", "confPrefix": "SMA_"}
+			{ "type": "ReferenceConcentrationParameter", "varName": ["refC0", "refQ"], "objName": "refConcentration", "confPrefix": "SMA_"}
 		]
 }
 </codegen>*/

--- a/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
+++ b/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
@@ -159,6 +159,8 @@ public:
 	{% endfor %}
 {% endif %}
 
+	inline char const* prefixInConfiguration() const CADET_NOEXCEPT { return ""; }
+
 protected:
 	inline bool validateConfig(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates);
 
@@ -383,6 +385,8 @@ public:
 		{% endif %}
 	{% endfor %}
 {% endif %}
+
+	inline char const* prefixInConfiguration() const CADET_NOEXCEPT { return "EXT_"; }
 
 protected:
 	inline bool validateConfig(unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates);

--- a/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
+++ b/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
@@ -86,14 +86,18 @@ public:
 	inline bool configure(IParameterProvider& paramProvider, unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
 	{
 {% for p in parameters %}
+	{% if not existsIn(p, "skipConfig") %}
 		_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+	{% endif %}
 {% endfor %}
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
-		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.configure("{{ p/confPrefix }}", paramProvider, nComp, nBoundStates);
-		{% else %}
-			_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+		{% if not existsIn(p, "skipConfig") %}
+			{% if length(p/varName) > 1 %}
+				_{{ p/objName }}.configure("{{ p/confPrefix }}", paramProvider, nComp, nBoundStates);
+			{% else %}
+				_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+			{% endif %}
 		{% endif %}
 	{% endfor %}
 {% endif %}
@@ -248,14 +252,18 @@ public:
 	inline bool configure(IParameterProvider& paramProvider, unsigned int nReactions, unsigned int nComp, unsigned int const* nBoundStates)
 	{
 {% for p in parameters %}
+	{% if not existsIn(p, "skipConfig") %}
 		_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+	{% endif %}
 {% endfor %}
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
-		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.configure("{{ p/confPrefix }}", paramProvider, nComp, nBoundStates);
-		{% else %}
-			_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+		{% if not existsIn(p, "skipConfig") %}
+			{% if length(p/varName) > 1 %}
+				_{{ p/objName }}.configure("{{ p/confPrefix }}", paramProvider, nComp, nBoundStates);
+			{% else %}
+				_{{ p/varName }}.configure("{{ p/confName }}", paramProvider, nComp, nBoundStates);
+			{% endif %}
 		{% endif %}
 	{% endfor %}
 {% endif %}

--- a/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
+++ b/src/libcadet/model/reaction/ExternalFunctionTemplate.cpp
@@ -74,7 +74,7 @@ public:
 		,
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}({% for v in p/varName %} &_localParams.{{ v }} {% if not is_last %},{% endif %} {% endfor %})
+			_{{ p/objName }}({% for v in p/varName %} &_localParams.{{ v }} {% if not is_last %},{% endif %} {% endfor %})
 		{% else %}
 			_{{ p/varName }}(&_localParams.{{ p/varName }})
 		{% endif %}
@@ -112,7 +112,7 @@ public:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.registerParam("{{ p/confPrefix }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
+			_{{ p/objName }}.registerParam("{{ p/confPrefix }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
 		{% else %}
 			_{{ p/varName }}.registerParam("{{ p/confName }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
 		{% endif %}
@@ -128,7 +128,7 @@ public:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.reserve(nReactions, nComp, nBoundStates);
+			_{{ p/objName }}.reserve(nReactions, nComp, nBoundStates);
 		{% else %}
 			_{{ p/varName }}.reserve(nReactions, nComp, nBoundStates);
 		{% endif %}
@@ -155,6 +155,9 @@ public:
 		{% if length(p/varName) == 1 %}
 			inline const {{ p/type }}& {{ p/varName }}() const CADET_NOEXCEPT { return _{{ p/varName }}; }
 			inline {{ p/type }}& {{ p/varName }}() CADET_NOEXCEPT { return _{{ p/varName }}; }
+		{% else %}
+			inline const {{ p/type }}& {{ p/objName }}() const CADET_NOEXCEPT { return _{{ p/objName }}; }
+			inline {{ p/type }}& {{ p/objName }}() CADET_NOEXCEPT { return _{{ p/objName }}; }
 		{% endif %}
 	{% endfor %}
 {% endif %}
@@ -172,7 +175,7 @@ protected:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/type }} {{ p/objName }};
+			{{ p/type }} _{{ p/objName }};
 		{% else %}
 			{{ p/type }} _{{ p/varName }};
 		{% endif %}
@@ -242,7 +245,7 @@ public:
 		:
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}({% for v in p/varName %} &_constParams.{{ v }} {% if not is_last %},{% endif %} {% endfor %})
+			_{{ p/objName }}({% for v in p/varName %} &_constParams.{{ v }} {% if not is_last %},{% endif %} {% endfor %})
 		{% else %}
 			_{{ p/varName }}(&_constParams.{{ p/varName }})
 		{% endif %}
@@ -281,7 +284,7 @@ public:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.registerParam("{{ p/confPrefix }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
+			_{{ p/objName }}.registerParam("{{ p/confPrefix }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
 		{% else %}
 			_{{ p/varName }}.registerParam("{{ p/confName }}", parameters, unitOpIdx, parTypeIdx, nComp, nBoundStates);
 		{% endif %}
@@ -297,7 +300,7 @@ public:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/objName }}.reserve(nReactions, nComp, nBoundStates);
+			_{{ p/objName }}.reserve(nReactions, nComp, nBoundStates);
 		{% else %}
 			_{{ p/varName }}.reserve(nReactions, nComp, nBoundStates);
 		{% endif %}
@@ -382,6 +385,9 @@ public:
 		{% if length(p/varName) == 1 %}
 			inline const {{ p/type }}& {{ p/varName }}() const CADET_NOEXCEPT { return _{{ p/varName }}; }
 			inline {{ p/type }}& {{ p/varName }}() CADET_NOEXCEPT { return _{{ p/varName }}; }
+		{% else %}
+			inline const {{ p/type }}& {{ p/objName }}() const CADET_NOEXCEPT { return _{{ p/objName }}; }
+			inline {{ p/type }}& {{ p/objName }}() CADET_NOEXCEPT { return _{{ p/objName }}; }
 		{% endif %}
 	{% endfor %}
 {% endif %}
@@ -399,7 +405,7 @@ protected:
 {% if exists("constantParameters") %}
 	{% for p in constantParameters %}
 		{% if length(p/varName) > 1 %}
-			{{ p/type }} {{ p/objName }};
+			{{ p/type }} _{{ p/objName }};
 		{% else %}
 			{{ p/type }} _{{ p/varName }};
 		{% endif %}

--- a/test/BindingModels.cpp
+++ b/test/BindingModels.cpp
@@ -593,13 +593,17 @@ CADET_BINDINGTEST("STERIC_MASS_ACTION", "EXT_STERIC_MASS_ACTION", (1,1,1), (1,1,
 	        "SMA_KD": [0.0, 10.0, 10.0],
 	        "SMA_NU": [1.5, 2.0, 1.5],
 	        "SMA_SIGMA": [0.0, 11.83, 10.6],
-	        "SMA_LAMBDA": 100.0
+	        "SMA_LAMBDA": 100.0,
+	        "SMA_REFC0": 2.0,
+	        "SMA_REFQ": 1.1
 	)json", \
 	R"json( "SMA_KA": [0.0, 3.55, 7.7, 1.59],
 	        "SMA_KD": [0.0, 10.0, 10.0, 10.0],
 	        "SMA_NU": [1.5, 2.0, 3.7, 1.5],
 	        "SMA_SIGMA": [0.0, 11.83, 10.0, 10.6],
-	        "SMA_LAMBDA": 100.0
+	        "SMA_LAMBDA": 100.0,
+	        "SMA_REFC0": 2.0,
+	        "SMA_REFQ": 1.1
 	)json", \
 	R"json( "EXT_SMA_KA": [0.0, 0.0, 0.0],
 	        "EXT_SMA_KA_T": [0.0, 3.55, 1.59],
@@ -620,7 +624,9 @@ CADET_BINDINGTEST("STERIC_MASS_ACTION", "EXT_STERIC_MASS_ACTION", (1,1,1), (1,1,
 	        "EXT_SMA_LAMBDA": 0.0,
 	        "EXT_SMA_LAMBDA_T": 100.0,
 	        "EXT_SMA_LAMBDA_TT": 0.0,
-	        "EXT_SMA_LAMBDA_TTT": 0.0
+	        "EXT_SMA_LAMBDA_TTT": 0.0,
+	        "EXT_SMA_REFC0": 2.0,
+	        "EXT_SMA_REFQ": 1.1
 	)json", \
 	R"json( "EXT_SMA_KA": [0.0, 0.0, 0.0, 0.0],
 	        "EXT_SMA_KA_T": [0.0, 3.55, 7.7, 1.59],
@@ -641,7 +647,9 @@ CADET_BINDINGTEST("STERIC_MASS_ACTION", "EXT_STERIC_MASS_ACTION", (1,1,1), (1,1,
 	        "EXT_SMA_LAMBDA": 0.0,
 	        "EXT_SMA_LAMBDA_T": 100.0,
 	        "EXT_SMA_LAMBDA_TT": 0.0,
-	        "EXT_SMA_LAMBDA_TTT": 0.0
+	        "EXT_SMA_LAMBDA_TTT": 0.0,
+	        "EXT_SMA_REFC0": 2.0,
+	        "EXT_SMA_REFQ": 1.1
 	)json", \
 	1e-10, 1e-8, CADET_NONBINDING_LIQUIDPHASE_COMP_UNUSED, CADET_COMPARE_BINDING_VS_NONBINDING);
 
@@ -952,7 +960,11 @@ CADET_BINDINGTEST("GENERALIZED_ION_EXCHANGE", "EXT_GENERALIZED_ION_EXCHANGE", (1
 	        "GIEX_NU_LIN": [0.0, 0.0, 0.5, 1.1],
 	        "GIEX_NU_QUAD": [0.0, 0.0, 0.8, 0.9],
 	        "GIEX_SIGMA": [0.0, 0.0, 11.83, 10.6],
-	        "GIEX_LAMBDA": 100.0
+	        "GIEX_LAMBDA": 100.0,
+	        "GIEX_REFC0": 2.0,
+	        "GIEX_REFQ": 50.0,
+	        "GIEX_PHREFC0": 2.5,
+	        "GIEX_PHREFQ": 45.0
 	)json", \
 	R"json( "GIEX_KA": [0.0, 0.0, 3.55, 7.7, 1.59],
 	        "GIEX_KA_LIN": [0.0, 0.0, 0.8, 1.2, 0.9],
@@ -968,7 +980,11 @@ CADET_BINDINGTEST("GENERALIZED_ION_EXCHANGE", "EXT_GENERALIZED_ION_EXCHANGE", (1
 	        "GIEX_NU_LIN": [0.0, 0.0, 0.5, 1.3, 1.1],
 	        "GIEX_NU_QUAD": [0.0, 0.0, 0.8, 4.7, 0.9],
 	        "GIEX_SIGMA": [0.0, 0.0, 11.83, 10.0, 10.6],
-	        "GIEX_LAMBDA": 100.0
+	        "GIEX_LAMBDA": 100.0,
+	        "GIEX_REFC0": 2.0,
+	        "GIEX_REFQ": 50.0,
+	        "GIEX_PHREFC0": 2.5,
+	        "GIEX_PHREFQ": 45.0
 	)json", \
 	R"json( "EXT_GIEX_KA": [0.0, 0.0, 0.0, 0.0],
 	        "EXT_GIEX_KA_T": [0.0, 0.0, 3.55, 1.59],
@@ -1029,7 +1045,11 @@ CADET_BINDINGTEST("GENERALIZED_ION_EXCHANGE", "EXT_GENERALIZED_ION_EXCHANGE", (1
 	        "EXT_GIEX_LAMBDA": 0.0,
 	        "EXT_GIEX_LAMBDA_T": 100.0,
 	        "EXT_GIEX_LAMBDA_TT": 0.0,
-	        "EXT_GIEX_LAMBDA_TTT": 0.0
+	        "EXT_GIEX_LAMBDA_TTT": 0.0,
+	        "EXT_GIEX_REFC0": 2.0,
+	        "EXT_GIEX_REFQ": 50.0,
+	        "EXT_GIEX_PHREFC0": 2.5,
+	        "EXT_GIEX_PHREFQ": 45.0
 	)json", \
 	R"json( "EXT_GIEX_KA": [0.0, 0.0, 0.0, 0.0, 0.0],
 	        "EXT_GIEX_KA_T": [0.0, 0.0, 3.55, 7.7, 1.59],
@@ -1090,7 +1110,11 @@ CADET_BINDINGTEST("GENERALIZED_ION_EXCHANGE", "EXT_GENERALIZED_ION_EXCHANGE", (1
 	        "EXT_GIEX_LAMBDA": 0.0,
 	        "EXT_GIEX_LAMBDA_T": 100.0,
 	        "EXT_GIEX_LAMBDA_TT": 0.0,
-	        "EXT_GIEX_LAMBDA_TTT": 0.0
+	        "EXT_GIEX_LAMBDA_TTT": 0.0,
+	        "EXT_GIEX_REFC0": 2.0,
+	        "EXT_GIEX_REFQ": 50.0,
+	        "EXT_GIEX_PHREFC0": 2.5,
+	        "EXT_GIEX_PHREFQ": 45.0
 	)json", \
 	1e-10, 1e-8, CADET_NONBINDING_LIQUIDPHASE_COMP_USED, CADET_COMPARE_BINDING_VS_NONBINDING);
 


### PR DESCRIPTION
Separates the power terms in the Generalized Ion Exchange adsorption model into constant and pH dependent powers. For the latter, a separate reference concentration is introduced.
If not provided explicitly, this additional reference is set to the standard reference concentration to maintain backwards compatibility.

Fixes #61.