### PR TITLE
Fix _nThreads lower bound to 0

### DIFF
--- a/src/libcadet/SimulatorImpl.cpp
+++ b/src/libcadet/SimulatorImpl.cpp
@@ -1472,7 +1472,7 @@ namespace cadet
 
 		paramProvider.popScope();
 
-		if (paramProvider.exists("NTHREADS"))
+		if (paramProvider.exists("NTHREADS") && (paramProvider.getInt("NTHREADS") > 0))
 			_nThreads = paramProvider.getInt("NTHREADS");
 		else
 			_nThreads = 0;

--- a/src/libcadet/SimulatorImpl.cpp
+++ b/src/libcadet/SimulatorImpl.cpp
@@ -1472,8 +1472,12 @@ namespace cadet
 
 		paramProvider.popScope();
 
-		if (paramProvider.exists("NTHREADS") && (paramProvider.getInt("NTHREADS") > 0))
-			_nThreads = paramProvider.getInt("NTHREADS");
+		if (paramProvider.exists("NTHREADS"))
+		{
+			// Ensure numThreads >= 0
+			const int numThreads = paramProvider.getInt("NTHREADS");
+			_nThreads = std::max(numThreads, 0);
+		}
 		else
 			_nThreads = 0;
 


### PR DESCRIPTION
_nThreads (type `unsigned int`) now defaults to 0 if NTHREADS is
less than 0.
