### PR TITLE
Make debugging on Windows more convenient

### DIFF
--- a/src/cadet-cli/CMakeLists.txt
+++ b/src/cadet-cli/CMakeLists.txt
@@ -29,6 +29,17 @@ if (ENABLE_STATIC_LINK_CLI)
 	target_link_libraries(cadet-cli PRIVATE libcadet_static)
 else()
 	target_link_libraries(cadet-cli PRIVATE libcadet_shared)
+
+	# On Windows, copy libcadet.dll file to directory of cadet-cli.exe in order to ease debugging
+	if (WIN32)
+		add_custom_command(
+			TARGET cadet-cli
+			POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy
+				$<TARGET_FILE:libcadet_shared>
+				$<TARGET_FILE_DIR:cadet-cli>/$<TARGET_FILE_NAME:libcadet_shared>
+		)
+	endif()
 endif()
   
 # Add include directories for access to exported LIBCADET header files.

--- a/src/libcadet/SimulatorImpl.cpp
+++ b/src/libcadet/SimulatorImpl.cpp
@@ -1309,7 +1309,9 @@ namespace cadet
 						IDAGetSensDky(_idaMemBlock, curT, 1, _vecFwdYsDot);
 					}
 					writeSolution(curT);
-					++it;
+
+					if (writeAtUserTimes)
+						++it;
 
 					// Notify user and check for user abort
 					if (_notification)


### PR DESCRIPTION
Fixes an assert that is triggered when compiling with MSVC in debug mode. Apparently, MSVC's standard library considers advancing an uninitialized vector iterator as problematic. This happens when a simulation is run without user-defined output times.

Debugging CADET on Windows is made more convenient by copying the freshly built `cadet.dll` file to the directory of `cadet-cli.exe` (post build event). This ensures that `cadet.dll` is always found by `cadet-cli.exe` and that the correct file is used. This problem does not exist on Linux or Mac OSX since we have linker paths embedded in the executable on these platforms.