### PR TITLE
Add documentation for colloidal model

### DIFF
--- a/doc/interface/binding/index.rst
+++ b/doc/interface/binding/index.rst
@@ -70,4 +70,5 @@ This group also takes precedence over a possibly existing ``/input/model/unit_XX
     freundlich_ldf
     hic_water_on_hydrophobic_surfaces
     hic_constant_water_activity
+    multi_component_colloidal
 

--- a/doc/interface/binding/multi_component_colloidal.rst
+++ b/doc/interface/binding/multi_component_colloidal.rst
@@ -1,0 +1,163 @@
+.. _multi_component_colloidal_config:
+
+Multi Component Colloidal
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Group /input/model/unit_XXX/adsorption – ADSORPTION_MODEL = MULTI_COMPONENT_COLLOIDAL**
+
+
+``IS_KINETIC``
+   Selects kinetic or quasi-stationary adsorption mode: 1 = kinetic, 0 =
+   quasi-stationary. If a single value is given, the mode is set for all
+   bound states. Otherwise, the adsorption mode is set for each bound
+   state separately.
+
+===================  =========================  =========================================
+**Type:** int        **Range:** {0,1}  		    **Length:** 1/NTOTALBND
+===================  =========================  =========================================
+
+``COL_PHI``
+   Phase ratio :math:`\Phi`
+
+**Unit:** :math:`m^{2} m_{s}^{-3}`
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** 1
+===================  =========================  =========================================
+
+``COL_KAPPA_EXP``
+   Screening term exponent factor :math:`\kappa_{ef}`
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** 1
+===================  =========================  =========================================
+
+``COL_KAPPA_FACT``
+   Screening term factor :math:`\kappa_{f}`
+
+**Unit:** :math:`m \cdot mM^{-1}`
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** 1
+===================  =========================  =========================================
+
+``COL_KAPPA_CONST``
+   Screening term constant :math:`\kappa_{c}`
+
+**Unit:** :math:`m`
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** 1
+===================  =========================  =========================================
+
+``COL_CORDNUM``
+   Coordination number :math:`n`
+
+===================  =========================  =========================================
+**Type:** int        **Range:** :math:`\ge 0`   **Length:** 1
+===================  =========================  =========================================
+
+``COL_LOGKEQ_PH_EXP``
+   Protein-resin interaction :math:`K_{e,i}` equilibrium: Constant exponent :math:`k_{e,i}` for pH
+   If pH is not considered, this value will be not be used but must still be specified, i.e. can be any number.
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_LOGKEQ_SALT_POWEXP``
+   Protein-resin interaction :math:`K_{e,i}` equilibrium: Constant pre-factor :math:`k_{a,i}` for salt power
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_LOGKEQ_SALT_POWFAC``
+   Protein-resin interaction :math:`K_{e,i}` equilibrium: Constant exponent :math:`k_{b,i}` for salt power
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_LOGKEQ_SALT_EXPFAC``
+   Protein-resin interaction :math:`K_{e,i}` equilibrium: Constant pre-factor :math:`k_{c,i}` for e-function with salt power
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_LOGKEQ_SALT_EXPARGMULT``
+   Protein-resin interaction :math:`K_{e,i}` equilibrium: Constant power factor :math:`k_{d,i}` for salt in e-function
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_BPP_PH_EXP``
+   Protein-protein interaction :math:`b_{pp,i}`: Constant power term :math:`b_{e,i}` for pH.
+   If pH is not considered, this value will be not be used but must still be specified, i.e. can be any number.
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_BPP_SALT_POWFACT``
+   Protein-protein interaction :math:`b_{pp,i}`: Constant power pre-factor :math:`b_{a,i}` for salt
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_BPP_SALT_POWEX``
+   Protein-protein interaction :math:`b_{pp,i}`: Constant power :math:`b_{b,i}` for salt
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_BPP_SALT_EXPFACT``
+   Protein-protein interaction :math:`b_{pp,i}`: Constant pre-factor :math:`b_{c,i}` e-function with salt power
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_BPP_SALT_EXPARGMULT``
+   Protein-protein interaction :math:`b_{pp,i}`: Constant power factor :math:`b_{d,i}` for salt in e-function 
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_PROTEIN_RADIUS``
+   Protein radius :math:`r_i`
+
+**Unit:** :math:`m`
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_KKIN``
+   Adsorption rate constants :math:`K_\text{kin}` in state-major ordering
+
+**Unit:** :math:`s^{-1}`
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`\ge 0`   **Length:** NTOTALBND
+===================  =========================  =========================================
+
+``COL_LINEAR_THRESHOLD``
+   Threshold concentration :math:`c_\epsilon` for switching to linear approximation
+
+===================  =========================  =========================================
+**Type:** double     **Range:** :math:`> 0`   **Length:** 1
+===================  =========================  =========================================
+
+``COL_USE_PH``
+   Selects if pH is included in the model or not: 1 = yes, 0 = no.
+
+===================  =========================  =========================================
+**Type:** int        **Range:** {0,1}           **Length:** 1
+===================  =========================  =========================================
+

--- a/doc/literature.bib
+++ b/doc/literature.bib
@@ -485,3 +485,16 @@ author = {Raena Morley and Mirjana Minceva},
 keywords = {Countercurrent chromatography, Centrifugal partition chromatography, Short-cut model, Continuous chromatography, Operating parameters, Dual mode},
 abstract = {The presence of a liquid stationary phase in liquid–liquid chromatography (LLC) allows for high versatility of operation as well as adaptability to different sample types and separation tasks. LLC, also known as countercurrent chromatography (CCC) or centrifugal partition chromatography (CPC), offers the user a variety of operating modes, many of which have no direct equivalent in conventional preparative liquid–solid chromatography. These operating modes have the potential to greatly improve LLC separation performance compared to the standard “classical” isocratic batch injection mode, and they often require minimal to no addition of equipment to the standard set-up. However, reports of the use of alternative LLC operating modes make up only a fraction of the literature. This is likely due, at least in part, to the lack of clear guidelines and methods for operating mode and parameter selection, leaving alternative process options to be avoided and underutilized. This review seeks to remedy this by providing a thorough overview of the available LLC operating modes, identifying the key characteristics, advantages and disadvantages, and areas of application of each. Additionally, the equations and short-cut models aiding in operating mode and parameter selection are presented and critiqued, and their notation is unified for clarity. By rendering LLC and its alternative operating modes more accessible to current and prospective users, it is hoped to help expand the application of this technology and support the achievement of its full potential.}
 }
+@article{Xu2009,
+	title = {Binary adsorption of globular proteins on ion-exchange media},
+	journal = {Journal of Chromatography A},
+	volume = {1216},
+	number = {34},
+	pages = {6177-6195},
+	year = {2009},
+	issn = {0021-9673},
+	doi = {https://doi.org/10.1016/j.chroma.2009.06.082},
+	url = {https://www.sciencedirect.com/science/article/pii/S0021967309010103},
+	author = {Xuankuo Xu and Abraham M. Lenhoff},
+	keywords = {Protein adsorption isotherms, Competitive adsorption, Protein–surface interactions, Protein–protein interactions, Colloidal interactions, Ion-exchange chromatography},
+}

--- a/doc/modelling/binding/index.rst
+++ b/doc/modelling/binding/index.rst
@@ -237,6 +237,11 @@ The models also differ in whether a mobile phase modifier (e.g., salt) is suppor
      - ✓
      - ✓
      - ✓
+   * - :ref:`multi_component_colloidal_model`
+     - ✓
+     - ✓
+     - ✓
+     - ×
    * - :ref:`generalized_ion_exchange_model`
      - ✓
      - ✓

--- a/doc/modelling/binding/multi_component_colloidal.rst
+++ b/doc/modelling/binding/multi_component_colloidal.rst
@@ -1,0 +1,77 @@
+.. _multi_component_colloidal_model:
+
+Multi Component Colloidal
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The colloidal isotherm assumes that adsorbed protein molecules are evenly distributed in a hexagonal arrangement at equilibrium, with the coverage varying via adjustment of the lattice size :cite:`Xu2009`. 
+Protein-surface interactions are captured in a parameter :math:`K_{e}`.
+The surface coverage is modulated at higher coverage, described by a Yukawa potential.
+The Yukawa constant :math:`b_{pp}` characterizes protein-protein interactions.
+Since these are long-ranged, they are assumed to be primarily electrostatic for ion-exchange chromatography, with the range of interactions determined by the Debye parameter, :math:`\kappa`.
+
+.. math::
+    \begin{aligned}
+        \frac{{dq}_{i}}{dt} = & k_{kin,i} \left( c_{p,i} -  c_{p,i}^\star \right) 
+         \quad
+         i = 0, \dots, N_{comp} - 1,
+         \\
+        c_{p,i}^\star = & q_{i} \exp  \Biggl[ \frac{n\left( 3 + \kappa R \right)}{4 q_{tot}} \sum_{j=0}^{N_{bound}} {q_{j} \sqrt{b_{pp,i} b_{pp,j}}} \frac{r_{i} + r_{j}}{2R}
+         \exp \bigl[ - \kappa \left( R - \left( r_{i} + r_{j} \right) \right) \bigr] \\
+         &\phantom{q_{i} \exp  \Biggl[} - ln \left(K_{e,i} \right) \Biggr], 
+    \end{aligned}
+
+where :math:`n` is the coordination number describing the two-dimensional lattice agreement of protein molecules on the resin surface (:math:`n=6` for hexagonal arrangement).
+:math:`r_{i}` is the radius of the protein, and :math:`K_{kin}` is the kinetic rate of adsorption.
+
+
+For the surface coverage factor :math:`R`, the following equation is used:
+
+.. math::
+
+    R = \sqrt{\frac{2 \phi}{N_{A} \cdot 10^{23} \cdot \sqrt{3} \cdot q_{tot}}},
+
+where :math:`\phi` is the phase ratio (surface area/solid phase volume), :math:`N_{A}` is Avogadro's number, and with
+
+.. math::
+
+    q_{tot} = \sum q_{i}.
+
+
+The screening term :math:`\kappa` is a Debye parameter based on the ideal colloidal phase behavior of the protein.
+In the case of ion exchange chromatography, this is the inverse of the Debye length.
+For other interaction mechanisms, this term can also be used to describe protein-protein interactions in general:
+
+.. math::
+
+    \kappa = \frac{1}{\kappa_f {c_{p,0}}^{\kappa_{ef}} + \kappa_{c}}.
+
+:math:`\kappa_{c}`, :math:`\kappa_{ef}`, and :math:`\kappa_{f}` are fitting constants which can be used to custom define the protein-protein interaction behavior based on additives in the mobile phase.
+:math:`c_{p,0}` is the total ionic strength, represented by the first component (non-binding pseudo component).
+
+Also the terms for protein-resin interaction, :math:`K_{e,i}`, and protein-protein interaction, :math:`b_{pp,i}`, are varied as a function of the ionic strength.
+
+.. math::
+
+    ln \left( K_{e, i} \right) &= k_{a,i} {c_{p, 0}}^{-k_{b,i}} + k_{c,i} \exp \left( k_{d,i} c_{p,0} \right)  \\
+    b_{pp,i} &= b_{a,i} {c_{p,0}}^{b_{b,i}} + b_{c,i} \exp \left( b_{d,i} c_{p,0} \right),
+
+Optionally, they can also be varied as a function of the pH, then represented by the second component (non-binding pseudo component, :math:`c_{p,1}`).
+
+.. math::
+
+    ln \left( K_{e, i} \right) &= {c_{p,1}}^{k_{e,i}} \left( k_{a,i} {c_{p, 0}}^{-k_{b,i}} + k_{c,i} \exp \left( k_{d,i} c_{p,0} \right) \right) \\
+    b_{pp,i} &= {c_{p,1}}^{b_{e,i}} \left( b_{a,i} {c_{p,0}}^{b_{b,i}} + b_{c,i} \exp \left( b_{d,i} c_{p,0} \right) \right),
+
+where :math:`k_{a-e}`, :math:`b_{a-e}` are fitting constants. 
+
+
+Because the model becomes mathematically singular at zero concentration, the original equation is replaced by its mathematical limit below a threshold concentration :math:`c_\epsilon > 0`.
+
+.. math::
+
+    \frac{{dq}_{i}}{dt} = k_{kin,i} \left(c_{p,i} - q_{i} \cdot \exp \left[ - ln \left( K_{e,i} \right) \right] \right).
+
+
+
+For more information on model parameters required to define in CADET file format, see :ref:`multi_component_colloidal_config`.
+

--- a/src/libcadet/model/binding/ColloidalBinding.cpp
+++ b/src/libcadet/model/binding/ColloidalBinding.cpp
@@ -45,7 +45,7 @@
 			{ "type": "ScalarComponentDependentParameter", "varName": "bppSaltPowerFact", "confName": "COL_BPP_SALT_POWFACT"},
 			{ "type": "ScalarComponentDependentParameter", "varName": "bppSaltExpFact", "confName": "COL_BPP_SALT_EXPFACT"},
 			{ "type": "ScalarComponentDependentParameter", "varName": "bppSaltExpExp", "confName": "COL_BPP_SALT_EXPARGMULT"},
-			{ "type": "ScalarComponentDependentParameter", "varName": "radius", "confName": "COL_RADIUS"},
+			{ "type": "ScalarComponentDependentParameter", "varName": "radius", "confName": "COL_PROTEIN_RADIUS"},
 			{ "type": "ScalarComponentDependentParameter", "varName": "kKin", "confName": "COL_KKIN"}
 		],
 	"constantParameters":
@@ -81,7 +81,7 @@ inline bool ColloidalParamHandler::validateConfig(unsigned int nComp, unsigned i
 			|| (_kEqPhExp.size() != _kKin.size())
 			|| (_kEqPhExp.size() < nComp)
 		)
-		throw InvalidParameterException("COL_LOGKEQ_PH_EXP, COL_LOGKEQ_SALT_POWEXP, COL_LOGKEQ_SALT_POWFACT, COL_LOGKEQ_SALT_EXPFACT, COL_LOGKEQ_SALT_EXPMULT, COL_RADIUS, and COL_KKIN have to have the same size");
+		throw InvalidParameterException("COL_LOGKEQ_PH_EXP, COL_LOGKEQ_SALT_POWEXP, COL_LOGKEQ_SALT_POWFACT, COL_LOGKEQ_SALT_EXPFACT, COL_LOGKEQ_SALT_EXPMULT, COL_PROTEIN_RADIUS, and COL_KKIN have to have the same size");
 
 	if ((_kEqPhExp.size() != _bppPhExp.size())
 			|| (_kEqPhExp.size() != _bppSaltPowerExp.size())
@@ -107,7 +107,7 @@ inline bool ExtColloidalParamHandler::validateConfig(unsigned int nComp, unsigne
 			|| (_kEqPhExp.size() != _kKin.size())
 			|| (_kEqPhExp.size() < nComp)
 		)
-		throw InvalidParameterException("EXTCOL_LOGKEQ_PH_EXP, EXTCOL_LOGKEQ_SALT_POWEXP, EXTCOL_LOGKEQ_SALT_POWFACT, EXTCOL_LOGKEQ_SALT_EXPFACT, EXTCOL_LOGKEQ_SALT_EXPMULT, EXTCOL_RADIUS, and EXTCOL_KKIN have to have the same size");
+		throw InvalidParameterException("EXTCOL_LOGKEQ_PH_EXP, EXTCOL_LOGKEQ_SALT_POWEXP, EXTCOL_LOGKEQ_SALT_POWFACT, EXTCOL_LOGKEQ_SALT_EXPFACT, EXTCOL_LOGKEQ_SALT_EXPMULT, COL_PROTEIN_RADIUS, and EXTCOL_KKIN have to have the same size");
 
 	if ((_kEqPhExp.size() != _bppPhExp.size())
 			|| (_kEqPhExp.size() != _bppSaltPowerExp.size())
@@ -398,10 +398,10 @@ protected:
 				if (phEnabled)
 				{
 					const double pH = yCp[1];
+					logKeq_dPh = pow(pH, static_cast<double>(p->kEqPhExp[i]) - 1.0) * static_cast<double>(p->kEqPhExp[i]) * logKeq;
 					const double pHfactor = pow(pH, static_cast<double>(p->kEqPhExp[i]));
 					logKeq *= pHfactor;
 					logKeq_dSalt *= pHfactor;
-					logKeq_dPh = pow(pH, static_cast<double>(p->kEqPhExp[i]) - 1.0) * static_cast<double>(p->kEqPhExp[i]) * logKeq;
 				}
 
 				double bpp_i = pow(cpSalt, static_cast<double>(p->bppSaltPowerExp[i])) * static_cast<double>(p->bppSaltPowerFact[i]) + exp(cpSalt * static_cast<double>(p->bppSaltExpExp[i])) * static_cast<double>(p->bppSaltExpFact[i]);

--- a/src/libcadet/model/binding/ColloidalBinding.cpp
+++ b/src/libcadet/model/binding/ColloidalBinding.cpp
@@ -251,7 +251,7 @@ protected:
 		}
 		else
 		{
-			const CpStateParamType kappa = 1e9 / (pow(cpSalt, static_cast<ParamType>(p->kappaExp)) * static_cast<ParamType>(p->kappaFact) + static_cast<ParamType>(p->kappaConst));
+			const CpStateParamType kappa = 1 / (pow(cpSalt, static_cast<ParamType>(p->kappaExp)) * static_cast<ParamType>(p->kappaFact) + static_cast<ParamType>(p->kappaConst));
 			const StateParamType R = sqrt(_rFactor * static_cast<ParamType>(p->phi) / qSum);
 			const StateParamType Sfactor = static_cast<ParamType>(p->cordNum) * 0.125 / qSum * (3.0 / R + kappa);
 
@@ -373,8 +373,8 @@ protected:
 		else
 		{
 			const double kappa_denom = pow(cpSalt, static_cast<double>(p->kappaExp)) * static_cast<double>(p->kappaFact) + static_cast<double>(p->kappaConst);
-			const double kappa = 1e9 / kappa_denom;
-			const double kappa_dSalt = -1e9 / sqr(kappa_denom) * pow(cpSalt, static_cast<double>(p->kappaExp) - 1.0) * static_cast<double>(p->kappaExp) * static_cast<double>(p->kappaFact);
+			const double kappa = 1 / kappa_denom;
+			const double kappa_dSalt = -1 / sqr(kappa_denom) * pow(cpSalt, static_cast<double>(p->kappaExp) - 1.0) * static_cast<double>(p->kappaExp) * static_cast<double>(p->kappaFact);
 			const double R = sqrt(_rFactor * static_cast<double>(p->phi) / qSum);
 			const double R_dq = -0.5 * R / qSum;
 			const double Sfactor = static_cast<double>(p->cordNum) * 0.125 / qSum * (3.0 / R + kappa);

--- a/test/BindingModels.cpp
+++ b/test/BindingModels.cpp
@@ -1245,76 +1245,111 @@ CADET_BINDINGTEST("GENERALIZED_ION_EXCHANGE", "EXT_GENERALIZED_ION_EXCHANGE", (1
 	)json", \
 	1e-10, 1e-8, CADET_NONBINDING_LIQUIDPHASE_COMP_USED, CADET_COMPARE_BINDING_VS_NONBINDING)
 
-// TODO: fix Jacobian (tests) for colloidal binding model
-//TEST_CASE("MULTI_COMPONENT_COLLOIDAL binding model analytic Jacobian vs AD with PH", "[Jacobian],[AD],[BindingModel],[MULTI_COMPONENT_COLLOIDAL]")
-//{
-//	const unsigned int nBound[] = {0, 0, 1, 1, 1};
-//	const double state[] = {0.9, 1.1, 1.5, 2.3, 2.9, 3.2, 2.1, 1.7};
-//	char const* const config = R"json({
-//			"COL_PHI": 0.56,
-//			"COL_KAPPA_EXP": 1.8,
-//			"COL_KAPPA_FACT": 1e7,
-//			"COL_KAPPA_CONST": 1.2,
-//			"COL_CORDNUM": 4.0,
-//			"COL_LOGKEQ_PH_EXP": [0.0, 0.0, 1.3, 2.3, 1.8],
-//			"COL_LOGKEQ_SALT_POWEXP": [0.0, 0.0, 1.4, 1.5, 1.6],
-//			"COL_LOGKEQ_SALT_POWFACT": [0.0, 0.0, 1.7, 1.9, 2.0],
-//			"COL_LOGKEQ_SALT_EXPFACT": [0.0, 0.0, 2.1, 2.2, 2.4],
-//			"COL_LOGKEQ_SALT_EXPARGMULT": [0.0, 0.0, 2.5, 2.6, 0.6],
-//			"COL_BPP_PH_EXP": [0.0, 0.0, 2.5, 2.4, 2.3],
-//			"COL_BPP_SALT_POWEXP": [0.0, 0.0, 1.1, 1.2, 1.3],
-//			"COL_BPP_SALT_POWFACT": [0.0, 0.0, 2.9, 2.8, 2.7],
-//			"COL_BPP_SALT_EXPFACT": [0.0, 0.0, 1.3, 1.7, 2.1],
-//			"COL_BPP_SALT_EXPARGMULT": [0.0, 0.0, 3.0, 2.8, 2.6],
-//			"COL_RADIUS": [0.0, 0.0, 1.1e-8, 2.0e-8, 3.0e-8],
-//			"COL_KKIN": [0.0, 0.0, 0.9, 1.4, 1.9],
-//			"COL_LINEAR_THRESHOLD": 1e-8,
-//			"COL_USE_PH": 1
-//		})json";
-//	for (int bindMode = 0; bindMode < 2; ++bindMode)
-//	{
-//		const bool isKinetic = bindMode;
-//		SECTION(std::string("Binding mode ") + (isKinetic ? "dynamic" : "quasi-stationary"))
-//		{
-//			cadet::test::binding::testJacobianAD("MULTI_COMPONENT_COLLOIDAL", sizeof(nBound) / sizeof(unsigned int), nBound, isKinetic, config, state);
-//		}
-//	}
-//}
-//
-//TEST_CASE("MULTI_COMPONENT_COLLOIDAL binding model analytic Jacobian vs AD without PH", "[Jacobian],[AD],[BindingModel],[MULTI_COMPONENT_COLLOIDAL]")
-//{
-//	const unsigned int nBound[] = {0, 1, 1, 1};
-//	const double state[] = {0.9, 1.1, 2.3, 2.9, 3.2, 2.1, 1.7};
-//	char const* const config = R"json({
-//			"COL_PHI": 0.56,
-//			"COL_KAPPA_EXP": 1.8,
-//			"COL_KAPPA_FACT": 1e7,
-//			"COL_KAPPA_CONST": 1.2,
-//			"COL_CORDNUM": 4.0,
-//			"COL_LOGKEQ_PH_EXP": [0.0, 1.3, 2.3, 1.8],
-//			"COL_LOGKEQ_SALT_POWEXP": [0.0, 1.4, 1.5, 1.6],
-//			"COL_LOGKEQ_SALT_POWFACT": [0.0, 1.7, 1.9, 2.0],
-//			"COL_LOGKEQ_SALT_EXPFACT": [0.0, 2.1, 2.2, 2.4],
-//			"COL_LOGKEQ_SALT_EXPARGMULT": [0.0, 2.5, 2.6, 0.6],
-//			"COL_BPP_PH_EXP": [0.0, 2.5, 2.4, 2.3],
-//			"COL_BPP_SALT_POWEXP": [0.0, 1.1, 1.2, 1.3],
-//			"COL_BPP_SALT_POWFACT": [0.0, 2.9, 2.8, 2.7],
-//			"COL_BPP_SALT_EXPFACT": [0.0, 1.3, 1.7, 2.1],
-//			"COL_BPP_SALT_EXPARGMULT": [0.0, 3.0, 2.8, 2.6],
-//			"COL_RADIUS": [0.0, 1.1e-8, 2.0e-8, 3.0e-8],
-//			"COL_KKIN": [0.0, 0.9, 1.4, 1.9],
-//			"COL_LINEAR_THRESHOLD": 1e-8,
-//			"COL_USE_PH": 0
-//		})json";
-//	for (int bindMode = 0; bindMode < 2; ++bindMode)
-//	{
-//		const bool isKinetic = bindMode;
-//		SECTION(std::string("Binding mode ") + (isKinetic ? "dynamic" : "quasi-stationary"))
-//		{
-//			cadet::test::binding::testJacobianAD("MULTI_COMPONENT_COLLOIDAL", sizeof(nBound) / sizeof(unsigned int), nBound, isKinetic, config, state);
-//		}
-//	}
-//}
+	TEST_CASE("MULTI_COMPONENT_COLLOIDAL binding model analytic Jacobian vs AD with PH single protein", "[Jacobian],[AD],[BindingModel],[MULTI_COMPONENT_COLLOIDAL]")
+			{
+				const unsigned int nBound[] = { 0, 0, 1 };
+				const double state[] = { 0.9, 1.1, 1.5e-2, 3.2e-2 };
+				char const* const config = R"json({
+			"COL_PHI": 49232983.6522396,
+			"COL_KAPPA_EXP": 1.8,
+			"COL_KAPPA_FACT": 1e7,
+			"COL_KAPPA_CONST": 1.2,
+			"COL_CORDNUM": 4.0,
+			"COL_LOGKEQ_PH_EXP": [0.0, 0.0, 1.3, 2.3, 1.8],
+			"COL_LOGKEQ_SALT_POWEXP": [0.0, 0.0, 1.4, 1.5, 1.6],
+			"COL_LOGKEQ_SALT_POWFACT": [0.0, 0.0, 1.7, 1.9, 2.0],
+			"COL_LOGKEQ_SALT_EXPFACT": [0.0, 0.0, 2.1, 2.2, 2.4],
+			"COL_LOGKEQ_SALT_EXPARGMULT": [0.0, 0.0, 2.5, 2.6, 0.6],
+			"COL_BPP_PH_EXP": [0.0, 0.0, 2.5, 2.4, 2.3],
+			"COL_BPP_SALT_POWEXP": [0.0, 0.0, 1.1, 1.2, 1.3],
+			"COL_BPP_SALT_POWFACT": [0.0, 0.0, 2.9, 2.8, 2.7],
+			"COL_BPP_SALT_EXPFACT": [0.0, 0.0, 1.3, 1.7, 2.1],
+			"COL_BPP_SALT_EXPARGMULT": [0.0, 0.0, 3.0, 2.8, 2.6],
+			"COL_PROTEIN_RADIUS": [0.0, 0.0, 1.1e-8, 2.0e-8, 3.0e-8],
+			"COL_KKIN": [0.0, 0.0, 0.9, 1.4, 1.9],
+			"COL_LINEAR_THRESHOLD": 1e-12,
+			"COL_USE_PH": 1
+		})json";
+				for (int bindMode = 0; bindMode < 2; ++bindMode)
+				{
+					const bool isKinetic = bindMode;
+					SECTION(std::string("Binding mode ") + (isKinetic ? "dynamic" : "quasi-stationary"))
+					{
+						cadet::test::binding::testJacobianAD("MULTI_COMPONENT_COLLOIDAL", sizeof(nBound) / sizeof(unsigned int), nBound, isKinetic, config, state);
+					}
+				}
+			}	
+
+
+	TEST_CASE("MULTI_COMPONENT_COLLOIDAL binding model analytic Jacobian vs AD with PH multi protein", "[Jacobian],[AD],[BindingModel],[MULTI_COMPONENT_COLLOIDAL]")
+	{
+		const unsigned int nBound[] = { 0, 0, 1, 1, 1};
+		const double state[] = { 0.9, 1.1, 1.5e-2, 3.2e-3, 1.5e-5, 3.2e-5, 1.5e-5, 3.2e-5 };
+		char const* const config = R"json({
+			"COL_PHI": 49232983.6522396,
+			"COL_KAPPA_EXP": 1.8,
+			"COL_KAPPA_FACT": 1e7,
+			"COL_KAPPA_CONST": 1.2,
+			"COL_CORDNUM": 4.0,
+			"COL_LOGKEQ_PH_EXP": [0.0, 0.0, 1.3, 2.3, 1.8],
+			"COL_LOGKEQ_SALT_POWEXP": [0.0, 0.0, 1.4, 1.5, 1.6],
+			"COL_LOGKEQ_SALT_POWFACT": [0.0, 0.0, 1.7, 1.9, 2.0],
+			"COL_LOGKEQ_SALT_EXPFACT": [0.0, 0.0, 2.1, 2.2, 2.4],
+			"COL_LOGKEQ_SALT_EXPARGMULT": [0.0, 0.0, 2.5, 2.6, 0.6],
+			"COL_BPP_PH_EXP": [0.0, 0.0, 2.5, 2.4, 2.3],
+			"COL_BPP_SALT_POWEXP": [0.0, 0.0, 1.1, 1.2, 1.3],
+			"COL_BPP_SALT_POWFACT": [0.0, 0.0, 2.9, 2.8, 2.7],
+			"COL_BPP_SALT_EXPFACT": [0.0, 0.0, 1.3, 1.7, 2.1],
+			"COL_BPP_SALT_EXPARGMULT": [0.0, 0.0, 3.0, 2.8, 2.6],
+			"COL_PROTEIN_RADIUS": [0.0, 0.0, 1.1e-8, 2.0e-8, 3.0e-8],
+			"COL_KKIN": [0.0, 0.0, 0.9, 1.4, 1.9],
+			"COL_LINEAR_THRESHOLD": 1e-12,
+			"COL_USE_PH": 1
+		})json";
+		for (int bindMode = 0; bindMode < 2; ++bindMode)
+		{
+			const bool isKinetic = bindMode;
+			SECTION(std::string("Binding mode ") + (isKinetic ? "dynamic" : "quasi-stationary"))
+			{
+				cadet::test::binding::testJacobianAD("MULTI_COMPONENT_COLLOIDAL", sizeof(nBound) / sizeof(unsigned int), nBound, isKinetic, config, state);
+			}
+		}
+	}
+
+TEST_CASE("MULTI_COMPONENT_COLLOIDAL binding model analytic Jacobian vs AD without PH", "[Jacobian],[AD],[BindingModel],[MULTI_COMPONENT_COLLOIDAL]")
+{
+	const unsigned int nBound[] = {0, 1, 1, 1};
+	const double state[] = {0.9, 1.1e-1, 3.2e-3, 1e-2, 2e-3, 1e-4, 1e-3};
+	char const* const config = R"json({
+			"COL_PHI": 49232983.6522396,
+			"COL_KAPPA_EXP": 1.8,
+			"COL_KAPPA_FACT": 1e7,
+			"COL_KAPPA_CONST": 1.2,
+			"COL_CORDNUM": 4.0,
+			"COL_LOGKEQ_PH_EXP": [0.0, 1.3, 2.3, 1.8],
+			"COL_LOGKEQ_SALT_POWEXP": [0.0, 1.4, 1.5, 1.6],
+			"COL_LOGKEQ_SALT_POWFACT": [0.0, 1.7, 1.9, 2.0],
+			"COL_LOGKEQ_SALT_EXPFACT": [0.0, 2.1, 2.2, 2.4],
+			"COL_LOGKEQ_SALT_EXPARGMULT": [0.0, 2.5, 2.6, 0.6],
+			"COL_BPP_PH_EXP": [0.0, 2.5, 2.4, 2.3],
+			"COL_BPP_SALT_POWEXP": [0.0, 1.1, 1.2, 1.3],
+			"COL_BPP_SALT_POWFACT": [0.0, 2.9, 2.8, 2.7],
+			"COL_BPP_SALT_EXPFACT": [0.0, 1.3, 1.7, 2.1],
+			"COL_BPP_SALT_EXPARGMULT": [0.0, 3.0, 2.8, 2.6],
+			"COL_PROTEIN_RADIUS": [0.0, 1.1e-8, 2.0e-8, 3.0e-8],
+			"COL_KKIN": [0.0, 0.9, 1.4, 1.9],
+			"COL_LINEAR_THRESHOLD": 1e-12,
+			"COL_USE_PH": 0
+		})json";
+	for (int bindMode = 0; bindMode < 2; ++bindMode)
+	{
+		const bool isKinetic = bindMode;
+		SECTION(std::string("Binding mode ") + (isKinetic ? "dynamic" : "quasi-stationary"))
+		{
+			cadet::test::binding::testJacobianAD("MULTI_COMPONENT_COLLOIDAL", sizeof(nBound) / sizeof(unsigned int), nBound, isKinetic, config, state);
+		}
+	}
+}
 
 TEST_CASE("MULTI_COMPONENT_COLLOIDAL binding model analytic Jacobian vs AD with PH low conc", "[Jacobian],[AD],[BindingModel],[MULTI_COMPONENT_COLLOIDAL]")
 {
@@ -1336,7 +1371,7 @@ TEST_CASE("MULTI_COMPONENT_COLLOIDAL binding model analytic Jacobian vs AD with 
 			"COL_BPP_SALT_POWFACT": [0.0, 0.0, 2.9, 2.8, 2.7],
 			"COL_BPP_SALT_EXPFACT": [0.0, 0.0, 1.3, 1.7, 2.1],
 			"COL_BPP_SALT_EXPARGMULT": [0.0, 0.0, 3.0, 2.8, 2.6],
-			"COL_RADIUS": [0.0, 0.0, 1.1e-8, 2.0e-8, 3.0e-8],
+			"COL_PROTEIN_RADIUS": [0.0, 0.0, 1.1e-8, 2.0e-8, 3.0e-8],
 			"COL_KKIN": [0.0, 0.0, 0.9, 1.4, 1.9],
 			"COL_LINEAR_THRESHOLD": 1e-5,
 			"COL_USE_PH": 1
@@ -1371,7 +1406,7 @@ TEST_CASE("MULTI_COMPONENT_COLLOIDAL binding model analytic Jacobian vs AD witho
 			"COL_BPP_SALT_POWFACT": [0.0, 2.9, 2.8, 2.7],
 			"COL_BPP_SALT_EXPFACT": [0.0, 1.3, 1.7, 2.1],
 			"COL_BPP_SALT_EXPARGMULT": [0.0, 3.0, 2.8, 2.6],
-			"COL_RADIUS": [0.0, 1.1e-8, 2.0e-8, 3.0e-8],
+			"COL_PROTEIN_RADIUS": [0.0, 1.1e-8, 2.0e-8, 3.0e-8],
 			"COL_KKIN": [0.0, 0.9, 1.4, 1.9],
 			"COL_LINEAR_THRESHOLD": 1e-5,
 			"COL_USE_PH": 0


### PR DESCRIPTION
This PR included the documentation for the previously undocumented colloidal model by [Xu et al](https://doi.org/10.1016/j.chroma.2009.06.082), implemented for Vijesh Kumar.

Before merging, some reviewing still needs to be conducted:

- [x] Decide if we want the pH to be proton concentration or pH. Should we decide to use proton concentration (preferred solution), we should add big warnings and also check the GIEX implementation.
    - [x] We decided to add it with pH and open a separate PR to add a flag for all isotherms with pH dependencies to use either proton concentration OR pH
- [x] update interface documentation with the coefficient names from the equations
- [x] Provide some general information about the purpose and assumptions of the model.
- [x] Add some more information about the coordination number. Also, I used n as the equation symbol (like here: https://en.wikipedia.org/wiki/Coordination_number)
- [x] A bracket was missing in the model equation (after exp⁡(-κ~[R-(r_i+r_j )]∙(3+κR))). Check whether it was corrected appropriately. 
- [x] In the parameters section, K_kin is described as adsorption kinetics, but in the text as reaction kinetics. Check which one is correct.
- [x] What is the meaning of the constants $\kappa _{c}$, $\kappa _{ef}$, and $\kappa _{f}$? Are they just fitting parameters?
- [x] COL_KAPPA_FACT, COL_KAPPA_CONST don't use SI units. Is this hard coded into the model? Usually, we want to only expose 'real' SI units (i.e. meter in this case) to the user. 
- [x] Fix Jacobian
- [x] Check tests

fixes #206 
