### PR TITLE
Hotfix/add documentation redirect

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,8 +4,8 @@
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=
-SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = source
+SPHINXBUILD   ?= sphinx-multiversion
+SOURCEDIR     = .
 BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
@@ -13,6 +13,9 @@ help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile
+
+clean:
+	rm -rf $(BUILDDIR)/*
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/doc/_assets/gh-pages-redirect.html
+++ b/doc/_assets/gh-pages-redirect.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://cadet.github.io/master/</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./master/index.html">
+    <link rel="canonical" href="https://cadet.github.io/master/index.html">
+  </head>
+</html>

--- a/doc/_templates/page.html
+++ b/doc/_templates/page.html
@@ -5,7 +5,7 @@
   <strong>
     {% if current_version.is_released %}
     You're reading an old version of this documentation.
-    If you want up-to-date information, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
+    For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
     {% else %}
     You're reading the documentation for a development version.
     For the latest released version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.

--- a/doc/_templates/versioning.html
+++ b/doc/_templates/versioning.html
@@ -1,8 +1,14 @@
 {% if versions %}
-<h3>{{ _('Versions') }}</h3>
+<h3>{{ _('Releases') }}</h3>
 <ul>
-      {%- for item in versions %}
-        <li><a href="{{ item.url }}">{{ item.name }}</a></li>
-          {%- endfor %}
+  {%- for item in versions.tags %}
+  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+  {%- endfor %}
+</ul>
+<h3>{{ _('Branches') }}</h3>
+<ul>
+  {%- for item in versions.branches %}
+  <li><a href="{{ item.url }}">{{ item.name }}</a></li>
+  {%- endfor %}
 </ul>
 {% endif %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,7 +37,7 @@ extensions = [
 bibtex_bibfiles = ['literature.bib']
 
 # Multiversion
-smv_released_pattern = r'^tags/.*$'         # Tags only
+smv_released_pattern = r'^refs/tags/.*$'    # Tags only
 smv_tag_whitelist = r'^v\d+\.\d+\.\d+$'     # Include tags like "v2.1.1"
 smv_branch_whitelist = r"^master$"          # Only use master branch
 smv_remote_whitelist = r"^origin$"          # Use branches from remote origin


### PR DESCRIPTION
This hotfix updates some settings for building the documentation and includes an html redirect. This is necessary because if we want to host multiple versions of the documentation, cadet.github.io now needs to be redirected to the latest version. 

Unfortunately, this also means, we need to update all of the links to the documentation (e.g. https://cadet.github.io/simulation/ now would be https://cadet.github.io/master/simulation/).

Due to some limitations with sphinx-multiversion, it is not possible to simply point to the latest release. Instead, for now I suggest always pointing to 'master'.
