### PR TITLE
Fix finding precompiled TBB on Linux

### DIFF
--- a/cmake/Modules/FindTBB.cmake
+++ b/cmake/Modules/FindTBB.cmake
@@ -191,9 +191,9 @@ if(NOT TBB_FOUND)
     #       <arch>/gcc4.1. For now, assume that the compiler is more recent than
     #       gcc 4.4.x or later.
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-      set(TBB_LIB_PATH_SUFFIX "lib/intel64/gcc4.4")
+      set(TBB_LIB_PATH_SUFFIX "lib/intel64/gcc4.1" "lib/intel64/gcc4.4" "lib/intel64/gcc4.8")
     elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^i.86$")
-      set(TBB_LIB_PATH_SUFFIX "lib/ia32/gcc4.4")
+      set(TBB_LIB_PATH_SUFFIX "lib/ia32/gcc4.1" "lib/ia32/gcc4.4" "lib/ia32/gcc4.8")
     endif()
   endif()
   


### PR DESCRIPTION
Adds the correct TBB_LIB_PATH_SUFFIX in order to find TBB using the
precompiled binaries on Linux. The path suffix only included gcc4.4,
but the current binaries use gcc4.8.