### PR TITLE
Fix issue with consistent initialization of LRM 

### DIFF
--- a/src/libcadet/model/LumpedRateModelWithoutPores.cpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPores.cpp
@@ -1359,7 +1359,7 @@ void LumpedRateModelWithoutPores::consistentInitialTimeDerivative(const Simulati
 
 		// Get iterators to beginning of solid phase
 		linalg::BandMatrix::RowIterator jacSolidOrig = _jac.row(idxr.strideColCell() * col + idxr.strideColLiquid());
-		linalg::FactorizableBandMatrix::RowIterator jacSolid = jac - idxr.strideColLiquid();
+		linalg::FactorizableBandMatrix::RowIterator jacSolid = jac - idxr.strideColBound();
 
 		int const* const mask = _binding[0]->reactionQuasiStationarity();
 		double* const qShellDot = vecStateYdot + idxr.offsetC() + col * idxr.strideColCell() + idxr.strideColLiquid();
@@ -1648,7 +1648,7 @@ void LumpedRateModelWithoutPores::consistentInitialSensitivity(const SimulationT
 			{
 				// Get iterators to beginning of solid phase
 				linalg::BandMatrix::RowIterator jacSolidOrig = _jac.row(idxr.strideColCell() * col + idxr.strideColLiquid());
-				linalg::FactorizableBandMatrix::RowIterator jacSolid = jac - idxr.strideColLiquid();
+				linalg::FactorizableBandMatrix::RowIterator jacSolid = jac - idxr.strideColBound();
 
 				int const* const mask = _binding[0]->reactionQuasiStationarity();
 				double* const qShellDot = sensYdot + idxr.offsetC() + idxr.strideColCell() * col + idxr.strideColLiquid();


### PR DESCRIPTION
For models with nbound > 1, consistent initialization would fail. This was due to a wrong indexer being called for the stationary state (strideColCell() instead of strideColBound().

@sleweke Before merging, we should check if this should also be fixed in other places of the code other than the two we found.

Fixes #100 