### PR TITLE
Fix stride error in writer

### DIFF
--- a/include/common/SolutionRecorderImpl.hpp
+++ b/include/common/SolutionRecorderImpl.hpp
@@ -591,7 +591,7 @@ protected:
 						else
 							oss << prefix << "_OUTLET_PORT_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << port;
 
-						writer.template matrix<double>(oss.str(), _numTimesteps, _nComp, _curStorage->outlet.data() + port * _nComp, _nOutletPorts, _nComp);
+						writer.template matrix<double>(oss.str(), _numTimesteps, _nComp, _curStorage->outlet.data() + port * _nComp, _nOutletPorts * _nComp, _nComp);
 					}
 				}
 			}
@@ -664,7 +664,7 @@ protected:
 						else
 							oss << prefix << "_INLET_PORT_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << port;
 
-						writer.template matrix<double>(oss.str(), _numTimesteps, _nComp, _curStorage->inlet.data() + port * _nComp, _nInletPorts, _nComp);
+						writer.template matrix<double>(oss.str(), _numTimesteps, _nComp, _curStorage->inlet.data() + port * _nComp, _nInletPorts * _nComp, _nComp);
 					}
 				}
 			}

--- a/include/common/SolutionRecorderImpl.hpp
+++ b/include/common/SolutionRecorderImpl.hpp
@@ -591,7 +591,7 @@ protected:
 						else
 							oss << prefix << "_OUTLET_PORT_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << port;
 
-						writer.template matrix<double>(oss.str(), _numTimesteps, _nComp, _curStorage->outlet.data() + port * _nComp, _nOutletPorts * _nComp, _nComp);
+						writer.template matrix<double>(oss.str(), _numTimesteps, _nComp, _curStorage->outlet.data() + port * _nComp, _nOutletPorts, _nComp);
 					}
 				}
 			}
@@ -664,7 +664,7 @@ protected:
 						else
 							oss << prefix << "_INLET_PORT_" << std::setfill('0') << std::setw(3) << std::setprecision(0) << port;
 
-						writer.template matrix<double>(oss.str(), _numTimesteps, _nComp, _curStorage->inlet.data() + port * _nComp, _nInletPorts * _nComp, _nComp);
+						writer.template matrix<double>(oss.str(), _numTimesteps, _nComp, _curStorage->inlet.data() + port * _nComp, _nInletPorts, _nComp);
 					}
 				}
 			}

--- a/include/io/hdf5/HDF5Writer.hpp
+++ b/include/io/hdf5/HDF5Writer.hpp
@@ -318,10 +318,10 @@ void HDF5Writer::writeWork(const std::string& dataSetName, hid_t memType, hid_t 
 	{
 		// Create strided memory data space
 		const hsize_t clampedStride = (stride < 1) ? 1 : stride;
-		const hsize_t numElem = H5Sget_simple_extent_npoints(dataSpace);
+		const hsize_t numElem = H5Sget_simple_extent_npoints(dataSpace) / blockSize;
 
 		// We need the actual array size (not just the number of elements to be written)
-		const hsize_t spaceExtent = numElem * clampedStride;
+		const hsize_t spaceExtent = numElem * (clampedStride + blockSize);
 		const hid_t memSpace = H5Screate_simple(1, &spaceExtent, nullptr);
 
 		const hsize_t start = 0;


### PR DESCRIPTION
In the case that `SPLIT_COMPONENTS_DATA = 0` and `SPLIT_PORTS_DATA = 1` solution was not written correctly.