### PR TITLE
Update repository dispatch for building docs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+
 
 jobs:
   Win64:

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -1,5 +1,8 @@
 name: "Trigger for dispatching CADET-Website"
-on: push
+on:
+  push:
+    branches:
+      - 'master'
 
 jobs:
   dispatch_docs:

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -5,10 +5,9 @@ jobs:
   dispatch_docs:
     runs-on: ubuntu-latest
     steps:
-      - name: Emit repository_dispatch
-        uses: mvasigh/dispatch-action@main
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.DISPATCH_DOCS }}
-          repo: CADET-Website
-          owner: modsim
-          event_type: build_docs
+          repository: modsim/CADET-Website
+          event-type: build_docs


### PR DESCRIPTION
This PR includes the following changes:
- Updates dispatch Action
- Only dispatch docs when pushing on `master`
- Run CI when pushing directly to `dev` or `master` and for PRs (prevents double evaluation in most cases)