### PR TITLE
Remove singleton parshell dims in solution of LRMP, CSTR

### DIFF
--- a/include/cadet/SolutionExporter.hpp
+++ b/include/cadet/SolutionExporter.hpp
@@ -59,6 +59,13 @@ public:
 	virtual bool hasVolume() const CADET_NOEXCEPT = 0;
 
 	/**
+	 * @brief Returns whether the particle is always lumped to a single element
+	 * @details If particles are lumped to a single element, the singleton particle shell dimension can be removed.
+	 * @return @c true if particles are always represented by a single element, otherwise @c false
+	 */
+	virtual bool isParticleLumped() const CADET_NOEXCEPT = 0;
+
+	/**
 	 * @brief Returns the number of components
 	 * @return Number of components
 	 */

--- a/src/libcadet/model/GeneralRateModel.hpp
+++ b/src/libcadet/model/GeneralRateModel.hpp
@@ -430,6 +430,7 @@ protected:
 		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return true; }
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound[_disc.nParType] > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
+		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }

--- a/src/libcadet/model/GeneralRateModel2D.hpp
+++ b/src/libcadet/model/GeneralRateModel2D.hpp
@@ -410,6 +410,7 @@ protected:
 		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return true; }
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound[_disc.nParType] > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
+		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }

--- a/src/libcadet/model/InletModel.hpp
+++ b/src/libcadet/model/InletModel.hpp
@@ -175,6 +175,7 @@ protected:
 		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return false; }
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return false; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
+		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 0; }

--- a/src/libcadet/model/LumpedRateModelWithPores.hpp
+++ b/src/libcadet/model/LumpedRateModelWithPores.hpp
@@ -360,6 +360,7 @@ protected:
 		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return true; }
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound[_disc.nParType] > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
+		virtual bool isParticleLumped() const CADET_NOEXCEPT { return true; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }

--- a/src/libcadet/model/LumpedRateModelWithoutPores.hpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPores.hpp
@@ -276,6 +276,7 @@ protected:
 		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return false; }
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
+		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }

--- a/src/libcadet/model/OutletModel.hpp
+++ b/src/libcadet/model/OutletModel.hpp
@@ -157,6 +157,7 @@ protected:
 		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return false; }
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return false; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
+		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 0; }

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -181,6 +181,7 @@ protected:
 		virtual bool hasParticleMobilePhase() const CADET_NOEXCEPT { return false; }
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _totalBound > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return true; }
+		virtual bool isParticleLumped() const CADET_NOEXCEPT { return true; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 0; }


### PR DESCRIPTION
Restores the previous behavior when reporting the solution of the LRMP and CSTR units: The singleton particle shell dimension is removed from the output tensor.

Fixes #133.