### PR TITLE
Fix missing CSTR bulk solution export

### DIFF
--- a/include/cadet/SolutionExporter.hpp
+++ b/include/cadet/SolutionExporter.hpp
@@ -66,6 +66,13 @@ public:
 	virtual bool isParticleLumped() const CADET_NOEXCEPT = 0;
 
 	/**
+	 * @brief Returns whether the primary coordinate is always a single element
+	 * @details If the primary coordinate is always a single element, the singleton dimension can be removed.
+	 * @return @c true if the state in the primary coordinate direction is always represented by a single element, otherwise @c false
+	 */
+	virtual bool hasPrimaryExtent() const CADET_NOEXCEPT = 0;
+
+	/**
 	 * @brief Returns the number of components
 	 * @return Number of components
 	 */

--- a/include/common/SolutionRecorderImpl.hpp
+++ b/include/common/SolutionRecorderImpl.hpp
@@ -58,7 +58,7 @@ public:
 	InternalStorageUnitOpRecorder(UnitOpIdx idx) : _cfgSolution({false, false, false, true, false, false, false}),
 		_cfgSolutionDot({false, false, false, false, false, false, false}), _cfgSensitivity({false, false, false, true, false, false, false}),
 		_cfgSensitivityDot({false, false, false, true, false, false, false}), _storeTime(false), _storeCoordinates(false), _splitComponents(true), _splitPorts(true),
-		_singleAsMultiPortUnitOps(false), _keepParticleSingletonDim(true), _curCfg(nullptr), _nComp(0), _nVolumeDof(0), _nAxialCells(0), _nRadialCells(0),
+		_singleAsMultiPortUnitOps(false), _keepBulkSingletonDim(true), _keepParticleSingletonDim(true), _curCfg(nullptr), _nComp(0), _nVolumeDof(0), _nAxialCells(0), _nRadialCells(0),
 		_nInletPorts(0), _nOutletPorts(0), _numTimesteps(0), _numSens(0), _unitOp(idx), _needsReAlloc(false), _axialCoords(0), _radialCoords(0), _particleCoords(0)
 	{
 	}
@@ -124,6 +124,7 @@ public:
 		_nInletPorts = exporter.numInletPorts();
 		_nOutletPorts = exporter.numOutletPorts();
 
+		_keepBulkSingletonDim = exporter.hasPrimaryExtent();
 		_keepParticleSingletonDim = !exporter.isParticleLumped();
 
 		_nAxialCells = exporter.numPrimaryCoordinates();
@@ -447,6 +448,9 @@ public:
 	inline bool treatSingleAsMultiPortUnitOps() const CADET_NOEXCEPT { return _singleAsMultiPortUnitOps; }
 	inline void treatSingleAsMultiPortUnitOps(bool smp) CADET_NOEXCEPT { _singleAsMultiPortUnitOps = smp; }
 
+	inline bool keepBulkSingletonDim() const CADET_NOEXCEPT { return _keepBulkSingletonDim; }
+	inline void keepBulkSingletonDim(bool keepSingleton) CADET_NOEXCEPT { _keepBulkSingletonDim = keepSingleton; }
+
 	inline bool keepParticleSingletonDim() const CADET_NOEXCEPT { return _keepParticleSingletonDim; }
 	inline void keepParticleSingletonDim(bool keepSingleton) CADET_NOEXCEPT { _keepParticleSingletonDim = keepSingleton; }
 
@@ -716,7 +720,7 @@ protected:
 			layout.reserve(4);
 			layout.push_back(_numTimesteps);
 
-			if (_nAxialCells > 0)
+			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
 				layout.push_back(_nAxialCells);
 			if (_nRadialCells > 0)
 				layout.push_back(_nRadialCells);
@@ -733,7 +737,7 @@ protected:
 			layout.reserve(5);
 			layout.push_back(_numTimesteps);
 
-			if (_nAxialCells > 0)
+			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
 				layout.push_back(_nAxialCells);
 			if (_nRadialCells > 0)
 				layout.push_back(_nRadialCells);
@@ -793,7 +797,7 @@ protected:
 			layout.reserve(5);
 			layout.push_back(_numTimesteps);
 
-			if (_nAxialCells > 0)
+			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
 				layout.push_back(_nAxialCells);
 			if (_nRadialCells > 0)
 				layout.push_back(_nRadialCells);
@@ -853,7 +857,7 @@ protected:
 
 			layout.push_back(_numTimesteps);
 			layout.push_back(_nParShells.size());
-			if (_nAxialCells > 0)
+			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
 				layout.push_back(_nAxialCells);
 			if (_nRadialCells > 0)
 				layout.push_back(_nRadialCells);
@@ -919,6 +923,7 @@ protected:
 	bool _splitComponents;
 	bool _splitPorts;
 	bool _singleAsMultiPortUnitOps;
+	bool _keepBulkSingletonDim;
 	bool _keepParticleSingletonDim;
 
 	StorageConfig const* _curCfg;

--- a/src/libcadet/model/GeneralRateModel.hpp
+++ b/src/libcadet/model/GeneralRateModel.hpp
@@ -431,6 +431,7 @@ protected:
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound[_disc.nParType] > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
+		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }

--- a/src/libcadet/model/GeneralRateModel2D.hpp
+++ b/src/libcadet/model/GeneralRateModel2D.hpp
@@ -411,6 +411,7 @@ protected:
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound[_disc.nParType] > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
+		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }

--- a/src/libcadet/model/InletModel.hpp
+++ b/src/libcadet/model/InletModel.hpp
@@ -176,6 +176,7 @@ protected:
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return false; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
+		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 0; }

--- a/src/libcadet/model/LumpedRateModelWithPores.hpp
+++ b/src/libcadet/model/LumpedRateModelWithPores.hpp
@@ -361,6 +361,7 @@ protected:
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound[_disc.nParType] > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped() const CADET_NOEXCEPT { return true; }
+		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }

--- a/src/libcadet/model/LumpedRateModelWithoutPores.hpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPores.hpp
@@ -277,6 +277,7 @@ protected:
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _disc.strideBound > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
+		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return true; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _disc.nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return _disc.nCol; }

--- a/src/libcadet/model/OutletModel.hpp
+++ b/src/libcadet/model/OutletModel.hpp
@@ -158,6 +158,7 @@ protected:
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return false; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return false; }
 		virtual bool isParticleLumped() const CADET_NOEXCEPT { return false; }
+		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
 		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 0; }

--- a/src/libcadet/model/StirredTankModel.hpp
+++ b/src/libcadet/model/StirredTankModel.hpp
@@ -182,9 +182,10 @@ protected:
 		virtual bool hasSolidPhase() const CADET_NOEXCEPT { return _totalBound > 0; }
 		virtual bool hasVolume() const CADET_NOEXCEPT { return true; }
 		virtual bool isParticleLumped() const CADET_NOEXCEPT { return true; }
+		virtual bool hasPrimaryExtent() const CADET_NOEXCEPT { return false; }
 
 		virtual unsigned int numComponents() const CADET_NOEXCEPT { return _nComp; }
-		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 0; }
+		virtual unsigned int numPrimaryCoordinates() const CADET_NOEXCEPT { return 1; }
 		virtual unsigned int numSecondaryCoordinates() const CADET_NOEXCEPT { return 0; }
 		virtual unsigned int numInletPorts() const CADET_NOEXCEPT { return 1; }
 		virtual unsigned int numOutletPorts() const CADET_NOEXCEPT { return 1; }
@@ -214,7 +215,11 @@ protected:
 
 		virtual double const* solidPhase(unsigned int parType) const { return _data + 2 * _nComp; }
 
-		virtual int writePrimaryCoordinates(double* coords) const { return 0; }
+		virtual int writePrimaryCoordinates(double* coords) const
+		{
+			coords[0] = 0.0;
+			return 1;
+		}
 		virtual int writeSecondaryCoordinates(double* coords) const { return 0; }
 		virtual int writeParticleCoordinates(unsigned int parType, double* coords) const { return 0; }
 


### PR DESCRIPTION
The CSTR model now reports 1 primary coordinate element. To comply with the interface, it also returns a coordinate value.

Because of the primary coordinate, the shape of the written bulk solution will be `(numTimesteps, 1, numComponents)`. This is a breaking change compared to previous versions. In order to selectively remove the singleton dimension, the function `hasPrimaryExtent()` is added to the `ISolutionExporter` interface. This flag determines whether the unit operation model actually extents in the primary coordinate direction, that is, whether it is a true spatial element. If a unit operation model does not have primary extent, the singleton dimension will be removed.

Fixes #149.