### PR TITLE
Fix/flux structure

### DIFF
--- a/include/common/SolutionRecorderImpl.hpp
+++ b/include/common/SolutionRecorderImpl.hpp
@@ -864,11 +864,11 @@ protected:
 			layout.reserve(5);
 
 			layout.push_back(_numTimesteps);
-			layout.push_back(_nParShells.size());
 			if ((_keepBulkSingletonDim && (_nAxialCells == 1)) || (_nAxialCells > 1))
 				layout.push_back(_nAxialCells);
 			if (_nRadialCells > 0)
 				layout.push_back(_nRadialCells);
+			layout.push_back(_nParShells.size());
 			layout.push_back(_nComp);
 
 			debugCheckTensorLayout(layout, _curStorage->flux.size());


### PR DESCRIPTION
The ordering of the flux was not consistent with other solution types. For a consistent interface, this PR reorders the flux structure.

Since flux is hardly used by anyone, I believe a breaking change is justifiable.

@sleweke: Is it enough to change the solution layout or do we also need to restructure the contents of the state vector?