### PR TITLE
Fix timing precision

### DIFF
--- a/include/common/Timer.hpp
+++ b/include/common/Timer.hpp
@@ -337,7 +337,7 @@ namespace cadet
 
 				inline double stopCore() const
 				{
-					return std::chrono::duration_cast<std::chrono::seconds>(std::chrono::high_resolution_clock::now() - _startTime).count();
+					return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - _startTime).count() * 1e-9;
 				}
 
 			protected:


### PR DESCRIPTION
Increase timing precision to nanoseconds with threading disabled. Threading was enabled by default before commit c2ef5fc51, which is probably why no one saw this issue before.

Fixes #197 