### PR TITLE
Update to cpp23 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,7 +430,7 @@ endif()
 # ---------------------------------------------------
 
 add_library(CADET::CompileOptions INTERFACE IMPORTED)
-target_compile_features(CADET::CompileOptions INTERFACE cxx_std_17)
+target_compile_features(CADET::CompileOptions INTERFACE cxx_std_23)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 if (WIN32)

--- a/ThirdParty/tclap/include/tclap/ArgTraits.h
+++ b/ThirdParty/tclap/include/tclap/ArgTraits.h
@@ -82,6 +82,6 @@ struct ArgTraits {
     //typedef ValueLike ValueCategory;
 };
 
-#endif
-
 } // namespace
+
+#endif

--- a/ThirdParty/tclap/include/tclap/MultiArg.h
+++ b/ThirdParty/tclap/include/tclap/MultiArg.h
@@ -239,7 +239,7 @@ private:
 	/**
 	 * Prevent accidental copying
 	 */
-	MultiArg<T>(const MultiArg<T>& rhs);
+	MultiArg(const MultiArg<T>& rhs);
 	MultiArg<T>& operator=(const MultiArg<T>& rhs);
 
 };

--- a/ThirdParty/tclap/include/tclap/ValueArg.h
+++ b/ThirdParty/tclap/include/tclap/ValueArg.h
@@ -254,7 +254,7 @@ private:
        /**
         * Prevent accidental copying
         */
-       ValueArg<T>(const ValueArg<T>& rhs);
+       ValueArg(const ValueArg<T>& rhs);
        ValueArg<T>& operator=(const ValueArg<T>& rhs);
 };
 

--- a/src/build-tools/CMakeLists.txt
+++ b/src/build-tools/CMakeLists.txt
@@ -16,7 +16,7 @@ project(CadetBuildTools CXX C)
 # Add the template code generator
 add_executable(templateCodeGen ${CMAKE_SOURCE_DIR}/src/build-tools/templateCodeGen.cpp)
 target_include_directories(templateCodeGen PRIVATE ${CMAKE_SOURCE_DIR}/ThirdParty/json ${CMAKE_SOURCE_DIR}/ThirdParty/inja)
-target_compile_features(templateCodeGen PRIVATE cxx_std_14)
+target_compile_features(templateCodeGen PRIVATE cxx_std_23)
 set_target_properties(templateCodeGen PROPERTIES CXX_EXTENSIONS OFF)
 
 # Info message


### PR DESCRIPTION
Updating the cpp standard could increase performance, due to optimazations wrt alignment of memory addresses.

tclap seems to have problems with the new standard and doesnt build on linux.

slice of the [linux build](https://github.com/modsim/CADET/actions/runs/9382068457/job/25832710893?pr=204):
```
/home/runner/work/CADET/CADET/src/ThirdParty/tclap/include/tclap/ValueArg.h:257:20: error: expected unqualified-id before ‘const’
  257 |        ValueArg<T>(const ValueArg<T>& rhs);
  ```