### PR TITLE
Temporarily add the developer_guide branch to sphinx multiversion

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,7 +46,7 @@ source_suffix = {
 # Multiversion
 smv_released_pattern = r'^refs/tags/.*$'    # Tags only
 smv_tag_whitelist = r'^v\d+\.\d+\.\d+$'     # Include tags like "v2.1.1"
-smv_branch_whitelist = r"^master$"          # Only use master branch
+smv_branch_whitelist = r"^(master|chore/developer_guide)$"          # Only use master branch
 smv_remote_whitelist = r"^origin$"          # Use branches from remote origin
 smv_outputdir_format = '{ref.name}'         # Use the branch/tag name
 


### PR DESCRIPTION
So that the developer guide is built for the website and can be viewed and linked to for people that need to read it. The default `master` website doesn't change, but we can select the website for the dev-guide branch from this selection:


![image](https://github.com/modsim/CADET/assets/18073230/f44bcf7d-7111-48df-865b-d0264710a5f1)
