### PR TITLE
Enable manual run of CI workflow for specific commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
       - dev
   pull_request:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit hash, branch name, or tag to run the CI pipeline for'
+        required: false
+        default: 'HEAD'
+        type: string
 
 
 jobs:
@@ -24,6 +30,7 @@ jobs:
         with:
           submodules: true
           path: src
+          ref: ${{ github.event.inputs.ref || github.ref }}
       - uses: ilammy/msvc-dev-cmd@v1
       - name: Get MSVC version
         id: get-msvc
@@ -131,6 +138,7 @@ jobs:
         with:
           submodules: true
           path: src
+          ref: ${{ github.event.inputs.ref || github.ref }}
       - name: Install Dependencies
         run: |
           sudo apt-get update
@@ -175,6 +183,7 @@ jobs:
         with:
           submodules: true
           path: src
+          ref: ${{ github.event.inputs.ref || github.ref }}
       - name: Install Dependencies
         run: |
           brew update > /dev/null || true


### PR DESCRIPTION
#202 was actually not fully resolved by #203 , which only enabled manually running the CI workflow, but not for a specific commit.
This PR fixes that. Changes were made according to the [corresponding github doc](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) and the [actions readme doc](https://github.com/actions/checkout).

Unfortunately theres no way of testing this, the changes have to be on the default branch so that we can test the manual rerun for specific commits.