### PR TITLE
Automatically compute binding model Jacobians via AD

### DIFF
--- a/src/libcadet/BindingModelFactory.cpp
+++ b/src/libcadet/BindingModelFactory.cpp
@@ -30,6 +30,7 @@ namespace cadet
 			void registerMobilePhaseModulatorLangmuirModel(std::unordered_map<std::string, std::function<model::IBindingModel*()>>& bindings);
 			void registerExtendedMobilePhaseModulatorLangmuirModel(std::unordered_map<std::string, std::function<model::IBindingModel*()>>& bindings);
 			void registerStericMassActionModel(std::unordered_map<std::string, std::function<model::IBindingModel*()>>& bindings);
+			void registerNoJacobianStericMassActionModel(std::unordered_map<std::string, std::function<model::IBindingModel* ()>>& bindings);
 			void registerBiStericMassActionModel(std::unordered_map<std::string, std::function<model::IBindingModel*()>>& bindings);
 			void registerMultiStateStericMassActionModel(std::unordered_map<std::string, std::function<model::IBindingModel*()>>& bindings);
 //			void registerSimplifiedMultiStateStericMassActionModel(std::unordered_map<std::string, std::function<model::IBindingModel*()>>& bindings);
@@ -59,6 +60,7 @@ namespace cadet
 		model::binding::registerMobilePhaseModulatorLangmuirModel(_bindingModels);
 		model::binding::registerExtendedMobilePhaseModulatorLangmuirModel(_bindingModels);
 		model::binding::registerStericMassActionModel(_bindingModels);
+		model::binding::registerNoJacobianStericMassActionModel(_bindingModels);
 		model::binding::registerBiStericMassActionModel(_bindingModels);
 		model::binding::registerMultiStateStericMassActionModel(_bindingModels);
 //		model::binding::registerSimplifiedMultiStateStericMassActionModel(_bindingModels);

--- a/src/libcadet/model/BindingModel.hpp
+++ b/src/libcadet/model/BindingModel.hpp
@@ -107,13 +107,6 @@ public:
 	virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT = 0;
 
 	/**
-	 * @brief Returns whether the function analyticJacobian() is implemented or not
-	 * @details If analytic Jacobians are not implemented, the owning unit operation can default to AD.
-	 * @return @c true if analyticJacobian() is implemented, otherwise @c false
-	 */
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT = 0;
-
-	/**
 	 * @brief Sets fixed parameters of the binding model (e.g., the number of components and bound states)
 	 * @details This function is called prior to configure() by the underlying model.
 	 *          It can only be called once. Whereas non-structural model parameters
@@ -260,6 +253,14 @@ public:
 	 * @return Size of the workspace in bytes
 	 */
 	virtual unsigned int workspaceSize(unsigned int nComp, unsigned int totalNumBoundStates, unsigned int const* nBoundStates) const CADET_NOEXCEPT = 0;
+
+	/**
+	 * @brief Returns the amount of required AD seed vectors / directions
+	 * @details Only internally required AD directions count (e.g., for Jacobian computation).
+	 *          Directions used for parameter sensitivities should not be included here.
+	 * @return The number of required AD seed vectors / directions
+	 */
+	virtual unsigned int requiredADdirs() const CADET_NOEXCEPT = 0;
 
 	/**
 	 * @brief Evaluates the fluxes

--- a/src/libcadet/model/GeneralRateModel.cpp
+++ b/src/libcadet/model/GeneralRateModel.cpp
@@ -1007,11 +1007,12 @@ void GeneralRateModel<ConvDispOperator>::reportSolutionStructure(ISolutionRecord
 template <typename ConvDispOperator>
 unsigned int GeneralRateModel<ConvDispOperator>::requiredADdirs() const CADET_NOEXCEPT
 {
+	const unsigned int numDirsBinding = maxBindingAdDirs();
 #ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-	return _jacobianAdDirs;
+	return numDirsBinding + _jacobianAdDirs;
 #else
 	// If CADET_CHECK_ANALYTIC_JACOBIAN is active, we always need the AD directions for the Jacobian
-	return numAdDirsForJacobian();
+	return numDirsBinding + numAdDirsForJacobian();
 #endif
 }
 

--- a/src/libcadet/model/GeneralRateModel2D.cpp
+++ b/src/libcadet/model/GeneralRateModel2D.cpp
@@ -1101,11 +1101,12 @@ void GeneralRateModel2D::reportSolutionStructure(ISolutionRecorder& recorder) co
 
 unsigned int GeneralRateModel2D::requiredADdirs() const CADET_NOEXCEPT
 {
+	const unsigned int numDirsBinding = maxBindingAdDirs();
 #ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-	return _jacobianAdDirs;
+	return numDirsBinding + _jacobianAdDirs;
 #else
 	// If CADET_CHECK_ANALYTIC_JACOBIAN is active, we always need the AD directions for the Jacobian
-	return numAdDirsForJacobian();
+	return numDirsBinding + numAdDirsForJacobian();
 #endif
 }
 

--- a/src/libcadet/model/GeneralRateModelDG.cpp
+++ b/src/libcadet/model/GeneralRateModelDG.cpp
@@ -986,11 +986,12 @@ void GeneralRateModelDG::reportSolutionStructure(ISolutionRecorder& recorder) co
 
 unsigned int GeneralRateModelDG::requiredADdirs() const CADET_NOEXCEPT
 {
+	const unsigned int numDirsBinding = maxBindingAdDirs();
 #ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-	return _jacobianAdDirs;
+	return numDirsBinding + _jacobianAdDirs;
 #else
 	// If CADET_CHECK_ANALYTIC_JACOBIAN is active, we always need the AD directions for the Jacobian
-	return numAdDirsForJacobian();
+	return numDirsBinding + numAdDirsForJacobian();
 #endif
 }
 

--- a/src/libcadet/model/LumpedRateModelWithPores.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPores.cpp
@@ -734,11 +734,12 @@ void LumpedRateModelWithPores<ConvDispOperator>::reportSolutionStructure(ISoluti
 template <typename ConvDispOperator>
 unsigned int LumpedRateModelWithPores<ConvDispOperator>::requiredADdirs() const CADET_NOEXCEPT
 {
+	const unsigned int numDirsBinding = maxBindingAdDirs();
 #ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-	return _jacobianAdDirs;
+	return numDirsBinding + _jacobianAdDirs;
 #else
 	// If CADET_CHECK_ANALYTIC_JACOBIAN is active, we always need the AD directions for the Jacobian
-	return numAdDirsForJacobian();
+	return numDirsBinding + numAdDirsForJacobian();
 #endif
 }
 

--- a/src/libcadet/model/LumpedRateModelWithPoresDG.cpp
+++ b/src/libcadet/model/LumpedRateModelWithPoresDG.cpp
@@ -693,11 +693,12 @@ void LumpedRateModelWithPoresDG::reportSolutionStructure(ISolutionRecorder& reco
 
 unsigned int LumpedRateModelWithPoresDG::requiredADdirs() const CADET_NOEXCEPT
 {
+	const unsigned int numDirsBinding = maxBindingAdDirs();
 #ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-	return _jacobianAdDirs;
+	return numDirsBinding + _jacobianAdDirs;
 #else
 	// If CADET_CHECK_ANALYTIC_JACOBIAN is active, we always need the AD directions for the Jacobian
-	return numAdDirsForJacobian();
+	return numDirsBinding + numAdDirsForJacobian();
 #endif
 }
 

--- a/src/libcadet/model/LumpedRateModelWithoutPores.cpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPores.cpp
@@ -428,11 +428,12 @@ void LumpedRateModelWithoutPores<ConvDispOperator>::reportSolutionStructure(ISol
 template <typename ConvDispOperator>
 unsigned int LumpedRateModelWithoutPores<ConvDispOperator>::requiredADdirs() const CADET_NOEXCEPT
 {
+	const unsigned int numDirsBinding = maxBindingAdDirs();
 #ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-	return _jacobianAdDirs;
+	return numDirsBinding + _jacobianAdDirs;
 #else
 	// If CADET_CHECK_ANALYTIC_JACOBIAN is active, we always need the AD directions for the Jacobian
-	return _jac.stride();
+	return numDirsBinding + _jac.stride();
 #endif
 }
 

--- a/src/libcadet/model/LumpedRateModelWithoutPoresDG.cpp
+++ b/src/libcadet/model/LumpedRateModelWithoutPoresDG.cpp
@@ -384,10 +384,11 @@ namespace cadet
 
 		unsigned int LumpedRateModelWithoutPoresDG::requiredADdirs() const CADET_NOEXCEPT
 		{
+			const unsigned int numDirsBinding = maxBindingAdDirs();
 #ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-			return _jacobianAdDirs;
+			return numDirsBinding + _jacobianAdDirs;
 #else
-			return _convDispOp.requiredADdirs();
+			return numDirsBinding + _convDispOp.requiredADdirs();
 #endif
 		}
 

--- a/src/libcadet/model/StirredTankModel.cpp
+++ b/src/libcadet/model/StirredTankModel.cpp
@@ -444,9 +444,9 @@ void CSTRModel::reportSolutionStructure(ISolutionRecorder& recorder) const
 unsigned int CSTRModel::requiredADdirs() const CADET_NOEXCEPT
 {
 #ifndef CADET_CHECK_ANALYTIC_JACOBIAN
-	// We don't need AD if analytic Jaocbian is enabled
 	if (_analyticJac)
-		return 0;
+		// Only use AD if binding models require it
+		return maxBindingAdDirs();
 #endif
 
 	// We always need AD if CADET_CHECK_ANALYTIC_JACOBIAN and if analytic Jacobian is disabled

--- a/src/libcadet/model/UnitOperationBase.cpp
+++ b/src/libcadet/model/UnitOperationBase.cpp
@@ -43,6 +43,22 @@ UnitOperationBase::~UnitOperationBase() CADET_NOEXCEPT
 	delete _nonlinearSolver;
 }
 
+unsigned int UnitOperationBase::maxBindingAdDirs() const CADET_NOEXCEPT
+{
+	if (_singleBinding)
+	{
+		if (!_binding.empty())
+			return _binding[0]->requiredADdirs();
+		else
+			return 0;
+	}
+
+	unsigned int dirs = 0;
+	for (IBindingModel* bm : _binding)
+		dirs = std::max(dirs, bm->requiredADdirs());
+	return dirs;
+}
+
 void UnitOperationBase::clearBindingModels() CADET_NOEXCEPT
 {
 	if (_singleBinding)

--- a/src/libcadet/model/UnitOperationBase.hpp
+++ b/src/libcadet/model/UnitOperationBase.hpp
@@ -74,6 +74,8 @@ protected:
 	void configureNonlinearSolver(IParameterProvider& paramProvider);
 	void configureNonlinearSolver();
 
+	unsigned int maxBindingAdDirs() const CADET_NOEXCEPT;
+
 	UnitOpIdx _unitOpIdx; //!< Unit operation index
 	std::vector<IBindingModel*> _binding; //!< Binding model
 	bool _singleBinding; //!< Determines whether only a single binding model is present

--- a/src/libcadet/model/binding/AntiLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/AntiLangmuirBinding.cpp
@@ -91,8 +91,6 @@ public:
 
 	static const char* identifier() { return ParamHandler_t::identifier(); }
 
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
-
 	CADET_BINDINGMODELBASE_BOILERPLATE
 	
 protected:
@@ -100,6 +98,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/BiLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/BiLangmuirBinding.cpp
@@ -126,7 +126,6 @@ public:
 	virtual bool hasSalt() const CADET_NOEXCEPT { return false; }
 	virtual bool supportsMultistate() const CADET_NOEXCEPT { return true; }
 	virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual void timeDerivativeQuasiStationaryFluxes(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* y, double* dResDt, LinearBufferAllocator workSpace) const
 	{
@@ -215,6 +214,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
 
 	unsigned int _numBindingComp; //!< Number of binding components
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/BiLangmuirLDFBinding.cpp
+++ b/src/libcadet/model/binding/BiLangmuirLDFBinding.cpp
@@ -126,7 +126,6 @@ namespace cadet
 			virtual bool hasSalt() const CADET_NOEXCEPT { return false; }
 			virtual bool supportsMultistate() const CADET_NOEXCEPT { return true; }
 			virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
-			virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 			/*virtual void timeDerivativeQuasiStationaryFluxes(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* y, double* dResDt, LinearBufferAllocator workSpace) const
 			{
@@ -215,6 +214,8 @@ namespace cadet
 			using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
 
 			unsigned int _numBindingComp; //!< Number of binding components
+
+			virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 			template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 			int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/BiStericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/BiStericMassActionBinding.cpp
@@ -171,7 +171,6 @@ public:
 	virtual bool supportsMultistate() const CADET_NOEXCEPT { return true; }
 	virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
 	virtual bool hasQuasiStationaryReactions() const CADET_NOEXCEPT { return true; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool preConsistentInitialState(double t, unsigned int secIdx, const ColumnPosition& colPos, double* y, double const* yCp, LinearBufferAllocator workSpace) const
 	{
@@ -223,6 +222,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
 
 	unsigned int _numBindingComp; //!< Number of binding components
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/ColloidalBinding.cpp
+++ b/src/libcadet/model/binding/ColloidalBinding.cpp
@@ -146,8 +146,6 @@ public:
 
 	static const char* identifier() { return ParamHandler_t::identifier(); }
 
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
-
 	virtual void timeDerivativeQuasiStationaryFluxes(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* y, double* dResDt, LinearBufferAllocator workSpace) const
 	{
 		if (!this->hasQuasiStationaryReactions())
@@ -159,7 +157,7 @@ public:
 		// TODO: Compute derivative
 	}
 
-	CADET_BINDINGMODELBASE_BOILERPLATE
+	CADET_BINDINGMODEL_RESIDUAL_BOILERPLATE
 
 protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_paramHandler;
@@ -169,6 +167,8 @@ protected:
 
 	int _startIdx;
 	const double _rFactor;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return false; }
 
 	virtual bool configureImpl(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
 	{

--- a/src/libcadet/model/binding/DummyBinding.cpp
+++ b/src/libcadet/model/binding/DummyBinding.cpp
@@ -144,8 +144,8 @@ public:
 	virtual bool hasDynamicReactions() const CADET_NOEXCEPT { return true; }
 	virtual bool dependsOnTime() const CADET_NOEXCEPT { return false; }
 	virtual bool requiresWorkspace() const CADET_NOEXCEPT { return false; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 	virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return _stateQuasistationarity.data(); }
+	virtual unsigned int requiredADdirs() const CADET_NOEXCEPT { return 0; }
 
 	virtual bool preConsistentInitialState(double t, unsigned int secIdx, const ColumnPosition& colPos, double* y, double const* yCp, LinearBufferAllocator workSpace) const { return false; }
 	virtual void postConsistentInitialState(double t, unsigned int secIdx, const ColumnPosition& colPos, double* y, double const* yCp, LinearBufferAllocator workSpace) const { }
@@ -154,6 +154,8 @@ protected:
 	int _nComp; //!< Number of components
 	unsigned int const* _nBoundStates; //!< Array with number of bound states for each component
 	std::vector<int> _stateQuasistationarity; //!< Determines whether each bound state is quasi-stationary (@c true) or not (@c false)
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 };
 
 namespace binding

--- a/src/libcadet/model/binding/ExtendedMobilePhaseModulatorLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/ExtendedMobilePhaseModulatorLangmuirBinding.cpp
@@ -103,7 +103,6 @@ public:
 	static const char* identifier() { return ParamHandler_t::identifier(); }
 
 	virtual bool hasSalt() const CADET_NOEXCEPT { return true; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool configureModelDiscretization(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBound, unsigned int const* boundOffset)
 	{
@@ -154,6 +153,8 @@ protected:
 
 	std::vector<int> _mode; //!< Mode of each component (e.g., linear or modified Langmuir)
 	int _idxModifier; //!< Index of the modifier component
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/FreundlichLDFBinding.cpp
+++ b/src/libcadet/model/binding/FreundlichLDFBinding.cpp
@@ -87,8 +87,6 @@ namespace cadet
 
 			static const char* identifier() { return ParamHandler_t::identifier(); }
 
-			virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
-
 			CADET_BINDINGMODELBASE_BOILERPLATE
 
 		protected:
@@ -99,6 +97,8 @@ namespace cadet
 
 			const double _threshold = 1e-14;
 			
+			virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
+
 			template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 			int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,
 				CpStateType const* yCp, ResidualType* res, LinearBufferAllocator workSpace) const

--- a/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
+++ b/src/libcadet/model/binding/GeneralizedIonExchangeBinding.cpp
@@ -167,7 +167,6 @@ public:
 	virtual bool supportsMultistate() const CADET_NOEXCEPT { return false; }
 	virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
 	virtual bool hasQuasiStationaryReactions() const CADET_NOEXCEPT { return true; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool preConsistentInitialState(double t, unsigned int secIdx, const ColumnPosition& colPos, double* y, double const* yCp, LinearBufferAllocator workSpace) const
 	{
@@ -215,6 +214,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool configureImpl(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx)
 	{

--- a/src/libcadet/model/binding/HICConstantWaterActivityBinding.cpp
+++ b/src/libcadet/model/binding/HICConstantWaterActivityBinding.cpp
@@ -123,7 +123,6 @@ public:
 	virtual bool supportsMultistate() const CADET_NOEXCEPT { return false; }
 	virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
 	virtual bool hasQuasiStationaryReactions() const CADET_NOEXCEPT { return false; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool preConsistentInitialState(double t, unsigned int secIdx, const ColumnPosition& colPos, double* y, double const* yCp, LinearBufferAllocator workSpace) const
 	{
@@ -143,6 +142,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/HICWaterOnHydrophobicSurfacesBinding.cpp
+++ b/src/libcadet/model/binding/HICWaterOnHydrophobicSurfacesBinding.cpp
@@ -117,7 +117,6 @@ public:
 	virtual bool supportsMultistate() const CADET_NOEXCEPT { return false; }
 	virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
 	virtual bool hasQuasiStationaryReactions() const CADET_NOEXCEPT { return false; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool preConsistentInitialState(double t, unsigned int secIdx, const ColumnPosition& colPos, double* y, double const* yCp, LinearBufferAllocator workSpace) const
 	{
@@ -137,6 +136,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/KumarLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/KumarLangmuirBinding.cpp
@@ -116,7 +116,6 @@ public:
 	}
 
 	virtual bool hasSalt() const CADET_NOEXCEPT { return true; }	
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	CADET_BINDINGMODELBASE_BOILERPLATE
 
@@ -125,6 +124,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/LangmuirBinding.cpp
+++ b/src/libcadet/model/binding/LangmuirBinding.cpp
@@ -91,8 +91,6 @@ public:
 
 	static const char* identifier() { return ParamHandler_t::identifier(); }
 
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
-
 	virtual void timeDerivativeQuasiStationaryFluxes(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* y, double* dResDt, LinearBufferAllocator workSpace) const
 	{
 		if (!this->hasQuasiStationaryReactions())
@@ -149,6 +147,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/LangmuirLDFBinding.cpp
+++ b/src/libcadet/model/binding/LangmuirLDFBinding.cpp
@@ -91,8 +91,6 @@ public:
 
 	static const char* identifier() { return ParamHandler_t::identifier(); }
 
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
-
 	/*virtual void timeDerivativeQuasiStationaryFluxes(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* y, double* dResDt, LinearBufferAllocator workSpace) const
 	{
 		if (!this->hasQuasiStationaryReactions())
@@ -149,6 +147,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/LangmuirLDFCBinding.cpp
+++ b/src/libcadet/model/binding/LangmuirLDFCBinding.cpp
@@ -91,8 +91,6 @@ public:
 
 	static const char* identifier() { return ParamHandler_t::identifier(); }
 
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
-
 	/*virtual void timeDerivativeQuasiStationaryFluxes(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* y, double* dResDt, LinearBufferAllocator workSpace) const
 	{
 		if (!this->hasQuasiStationaryReactions())
@@ -149,6 +147,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/LinearBinding.cpp
+++ b/src/libcadet/model/binding/LinearBinding.cpp
@@ -401,7 +401,6 @@ public:
 	virtual const char* name() const CADET_NOEXCEPT { return ParamHandler_t::identifier(); }
 	virtual bool requiresConfiguration() const CADET_NOEXCEPT { return true; }
 	virtual bool usesParamProviderInDiscretizationConfig() const CADET_NOEXCEPT { return true; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool configureModelDiscretization(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBound, unsigned int const* boundOffset)
 	{
@@ -616,6 +615,7 @@ public:
 
 	virtual bool dependsOnTime() const CADET_NOEXCEPT { return ParamHandler_t::dependsOnTime(); }
 	virtual bool requiresWorkspace() const CADET_NOEXCEPT { return ParamHandler_t::requiresWorkspace(); }
+	virtual unsigned int requiredADdirs() const CADET_NOEXCEPT { return 0; }
 	virtual int const* reactionQuasiStationarity() const CADET_NOEXCEPT { return _reactionQuasistationarity.data(); }
 
 protected:
@@ -626,6 +626,8 @@ protected:
 	ParamHandler_t _paramHandler; //!< Parameters
 
 	std::unordered_map<ParameterId, active*> _parameters; //!< Map used to translate ParameterIds to actual variables
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos,

--- a/src/libcadet/model/binding/MobilePhaseModulatorLangmuirBinding.cpp
+++ b/src/libcadet/model/binding/MobilePhaseModulatorLangmuirBinding.cpp
@@ -103,7 +103,6 @@ public:
 	static const char* identifier() { return ParamHandler_t::identifier(); }
 
 	virtual bool hasSalt() const CADET_NOEXCEPT { return true; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool configureModelDiscretization(IParameterProvider& paramProvider, unsigned int nComp, unsigned int const* nBound, unsigned int const* boundOffset)
 	{
@@ -123,6 +122,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/MultiComponentSpreadingBinding.cpp
+++ b/src/libcadet/model/binding/MultiComponentSpreadingBinding.cpp
@@ -128,7 +128,6 @@ public:
 	virtual bool hasSalt() const CADET_NOEXCEPT { return false; }
 	virtual bool supportsMultistate() const CADET_NOEXCEPT { return true; }
 	virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	CADET_BINDINGMODELBASE_BOILERPLATE
 
@@ -139,6 +138,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
 
 	unsigned int _numBindingComp; //!< Number of binding components
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/MultiStateStericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/MultiStateStericMassActionBinding.cpp
@@ -156,7 +156,6 @@ public:
 		return res;
 	}
 
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 	virtual bool hasSalt() const CADET_NOEXCEPT { return true; }
 	virtual bool supportsMultistate() const CADET_NOEXCEPT { return true; }
 	virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
@@ -206,6 +205,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/SaskaBinding.cpp
+++ b/src/libcadet/model/binding/SaskaBinding.cpp
@@ -91,8 +91,6 @@ public:
 
 	static const char* identifier() { return ParamHandler_t::identifier(); }
 
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
-
 	virtual void timeDerivativeQuasiStationaryFluxes(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* yCp, double const* y, double* dResDt, LinearBufferAllocator workSpace) const
 	{
 		if (!this->hasQuasiStationaryReactions())
@@ -134,6 +132,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/SelfAssociationBinding.cpp
+++ b/src/libcadet/model/binding/SelfAssociationBinding.cpp
@@ -134,7 +134,6 @@ public:
 	virtual bool supportsMultistate() const CADET_NOEXCEPT { return false; }
 	virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
 	virtual bool hasQuasiStationaryReactions() const CADET_NOEXCEPT { return true; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool preConsistentInitialState(double t, unsigned int secIdx, const ColumnPosition& colPos, double* y, double const* yCp, LinearBufferAllocator workSpace) const
 	{
@@ -176,6 +175,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/SimplifiedMultiStateStericMassActionBinding.hpp
+++ b/src/libcadet/model/binding/SimplifiedMultiStateStericMassActionBinding.hpp
@@ -77,7 +77,6 @@ public:
 
 	virtual bool dependsOnTime() const CADET_NOEXCEPT { return false; }
 	virtual bool requiresWorkspace() const CADET_NOEXCEPT { return true; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool preConsistentInitialState(double t, unsigned int secIdx, const ColumnPosition& colPos, double* y, double const* yCp, LinearBufferAllocator workSpace) const;
 	virtual void postConsistentInitialState(double t, unsigned int secIdx, const ColumnPosition& colPos, double* y, double const* yCp, LinearBufferAllocator workSpace) const;
@@ -103,6 +102,8 @@ protected:
 	std::vector<active> _kWS_quad; //!< State transition rate from weak to strong state, quadratic factor
 	active _refC0; //! Liquid phase reference concentration
 	active _refQ; //! Solid phase reference concentration
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool configureImpl(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx);
 	

--- a/src/libcadet/model/binding/StericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/StericMassActionBinding.cpp
@@ -129,7 +129,6 @@ public:
 	virtual bool supportsMultistate() const CADET_NOEXCEPT { return false; }
 	virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
 	virtual bool hasQuasiStationaryReactions() const CADET_NOEXCEPT { return true; }
-	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	virtual bool preConsistentInitialState(double t, unsigned int secIdx, const ColumnPosition& colPos, double* y, double const* yCp, LinearBufferAllocator workSpace) const
 	{
@@ -172,6 +171,8 @@ protected:
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_reactionQuasistationarity;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nComp;
 	using ParamHandlerBindingModelBase<ParamHandler_t>::_nBoundStates;
+
+	virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
 
 	template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
 	int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,

--- a/src/libcadet/model/binding/StericMassActionBinding.cpp
+++ b/src/libcadet/model/binding/StericMassActionBinding.cpp
@@ -330,6 +330,34 @@ namespace binding
 	}
 }  // namespace binding
 
+class NoJacobianStericMassActionBinding : public model::StericMassActionBinding {
+
+public:
+
+	static const char* identity() { return "NO_JACOBIAN_STERIC_MASS_ACTION"; }
+
+	CADET_BINDINGMODELBASE_BOILERPLATE
+
+protected:
+
+	const char* name() const CADET_NOEXCEPT override { return identity(); }
+	bool implementsAnalyticJacobian() const CADET_NOEXCEPT override { return false; }
+
+	template <typename RowIterator>
+	void jacobianImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, double const* y, double const* yCp, int offsetCp, RowIterator jac, LinearBufferAllocator workSpace) const
+	{
+		BindingModelBase::jacobianImpl(t, secIdx, colPos, y, yCp, offsetCp, jac, workSpace);
+	}
+};
+
+namespace binding
+{
+	void registerNoJacobianStericMassActionModel(std::unordered_map<std::string, std::function<model::IBindingModel* ()>>& bindings)
+	{
+		bindings[NoJacobianStericMassActionBinding::identity()] = []() { return new NoJacobianStericMassActionBinding(); };
+	}
+}  // namespace binding
+
 }  // namespace model
 
 }  // namespace cadet

--- a/test/BindingModelAutoJacobian.cpp
+++ b/test/BindingModelAutoJacobian.cpp
@@ -13,17 +13,16 @@
 #include <catch.hpp>
 #include "Approx.hpp"
 #include "cadet/cadet.hpp"
-#include "common/Driver.hpp"
-#include "common/JsonParameterProvider.hpp"
 
 #define CADET_LOGGING_DISABLE
 #include "Logging.hpp"
+#include "LoggingUtils.hpp"
 
+#include "common/Driver.hpp"
+#include "common/JsonParameterProvider.hpp"
 #include "model/binding/BindingModelBase.hpp"
-
 #include "JacobianHelper.hpp"
 #include "Dummies.hpp"
-
 #include "linalg/DenseMatrix.hpp"
 #include "AdUtils.hpp"
 #include "AutoDiff.hpp"

--- a/test/BindingModelAutoJacobian.cpp
+++ b/test/BindingModelAutoJacobian.cpp
@@ -1,0 +1,159 @@
+// =============================================================================
+//  CADET
+//  
+//  Copyright © 2008-2024: The CADET Authors
+//            Please see the AUTHORS and CONTRIBUTORS file.
+//  
+//  All rights reserved. This program and the accompanying materials
+//  are made available under the terms of the GNU Public License v3.0 (or, at
+//  your option, any later version) which accompanies this distribution, and
+//  is available at http://www.gnu.org/licenses/gpl.html
+// =============================================================================
+
+#include <catch.hpp>
+#include "Approx.hpp"
+#include "cadet/cadet.hpp"
+
+#define CADET_LOGGING_DISABLE
+#include "Logging.hpp"
+
+#include "model/binding/BindingModelBase.hpp"
+
+#include "JacobianHelper.hpp"
+#include "Dummies.hpp"
+
+#include "linalg/DenseMatrix.hpp"
+#include "AdUtils.hpp"
+#include "AutoDiff.hpp"
+
+namespace cadet
+{
+	class BindingWithoutJacobian : public model::BindingModelBase
+	{
+	public:
+		BindingWithoutJacobian() { }
+
+		virtual const char* name() const CADET_NOEXCEPT { return "BindingWithoutJacobian"; }
+		virtual bool dependsOnTime() const CADET_NOEXCEPT { return false; }
+
+		virtual bool configureImpl(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx) override { return true; }
+		virtual bool hasSalt() const CADET_NOEXCEPT { return false; }
+		virtual bool supportsMultistate() const CADET_NOEXCEPT { return true; }
+		virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
+
+		CADET_BINDINGMODEL_RESIDUAL_BOILERPLATE
+	protected:
+		virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return false; }
+
+		template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
+		int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,
+			CpStateType const* yCp, ResidualType* res, LinearBufferAllocator workSpace) const
+		{
+			int bndIdx = 0;
+			for (int i = 0; i < _nComp; ++i)
+			{
+				// Skip components without bound states (bound state index bndIdx is not advanced)
+				if (_nBoundStates[i] == 0)
+					continue;
+
+				// Residual
+				for (int j = 0; j < _nBoundStates[i]; ++j)
+				{
+					res[bndIdx] = (i+2+j) * y[bndIdx] - (i+1) * yCp[i];
+
+					// Next bound state
+					++bndIdx;
+				}
+			}
+
+			return 0;
+		}
+	};
+
+	class BindingWithJacobian : public model::BindingModelBase
+	{
+	public:
+		BindingWithJacobian() { }
+
+		virtual const char* name() const CADET_NOEXCEPT { return "BindingWithJacobian"; }
+		virtual bool dependsOnTime() const CADET_NOEXCEPT { return false; }
+
+		virtual bool configureImpl(IParameterProvider& paramProvider, UnitOpIdx unitOpIdx, ParticleTypeIdx parTypeIdx) override { return true; }
+		virtual bool hasSalt() const CADET_NOEXCEPT { return false; }
+		virtual bool supportsMultistate() const CADET_NOEXCEPT { return true; }
+		virtual bool supportsNonBinding() const CADET_NOEXCEPT { return true; }
+
+		CADET_BINDINGMODEL_RESIDUAL_BOILERPLATE
+	protected:
+		virtual bool implementsAnalyticJacobian() const CADET_NOEXCEPT { return true; }
+
+		template <typename StateType, typename CpStateType, typename ResidualType, typename ParamType>
+		int fluxImpl(double t, unsigned int secIdx, const ColumnPosition& colPos, StateType const* y,
+			CpStateType const* yCp, ResidualType* res, LinearBufferAllocator workSpace) const
+		{
+			return 0;
+		}
+	};
+
+} // namespace cadet
+
+TEST_CASE("Automatic AD binding model Jacobian vs FD", "[BindingModel],[Jacobian]")
+{
+	cadet::BindingWithoutJacobian bm;
+	const int nComp = 4;
+	const int totalBoundStates = 5;
+	const int numDofs = nComp + totalBoundStates;
+	const unsigned int boundStates[] = {1, 0, 3, 1};
+	const unsigned int boundOffset[] = {0, 1, 1, 4};
+
+	const double yState[] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, -8.0, -9.0};
+
+	DummyParameterProvider pp;
+	bm.configureModelDiscretization(pp, nComp, boundStates, nullptr);
+
+	REQUIRE(bm.requiresWorkspace());
+	REQUIRE(bm.requiredADdirs() == nComp + totalBoundStates);
+
+	const unsigned int workspaceSize = bm.workspaceSize(4, totalBoundStates, boundOffset);
+	std::vector<char> buffer(workspaceSize, 0);
+	cadet::LinearBufferAllocator workSpace(buffer.data(), buffer.data() + workspaceSize);
+
+	// Enable AD
+	cadet::ad::setDirections(cadet::ad::getMaxDirections());
+
+	cadet::linalg::DenseMatrix jacAna;
+	jacAna.resize(numDofs, numDofs);
+	bm.analyticJacobian(1.0, 0u, cadet::ColumnPosition{0.0, 0.0, 0.0}, yState, nComp, jacAna.row(nComp), workSpace);
+
+	std::vector<double> y(numDofs, 0.0);
+	std::vector<double> dir(numDofs, 0.0);
+	std::vector<double> colA(totalBoundStates, 0.0);
+	std::vector<double> colB(totalBoundStates, 0.0);
+
+	// Compare against FD: Since our flux() is linear, the Jacobian should be exact
+	cadet::test::compareJacobianFD(
+		[=](double const* y, double* r) { std::fill_n(r, totalBoundStates, 0.0); bm.flux(0.0, 0u, cadet::ColumnPosition{0.0, 0.0, 0.0}, y + nComp, y, r, workSpace); },
+		[&](double const* y, double* r) { jacAna.submatrixMultiplyVector(y, nComp, 0, totalBoundStates, numDofs, r); },
+		y.data(), dir.data(), colA.data(), colB.data(), numDofs, totalBoundStates, 1e-7, 0.0, 1e-15
+	);
+}
+
+TEST_CASE("Automatic AD disabled for binding model with Jacobian", "[BindingModel],[Jacobian]")
+{
+	cadet::BindingWithJacobian bm;
+	const int nComp = 4;
+	const int totalBoundStates = 5;
+	const int numDofs = nComp + totalBoundStates;
+	const unsigned int boundStates[] = {1, 0, 3, 1};
+	const unsigned int boundOffset[] = {0, 1, 1, 4};
+
+	const double yState[] = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, -8.0, -9.0};
+
+	DummyParameterProvider pp;
+	bm.configureModelDiscretization(pp, nComp, boundStates, nullptr);
+
+	REQUIRE(!bm.requiresWorkspace());
+	REQUIRE(bm.requiredADdirs() == 0);
+
+	REQUIRE(bm.workspaceSize(4, totalBoundStates, boundOffset) == 0);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,7 +69,7 @@ add_executable(testRunner testRunner.cpp JsonTestModels.cpp ColumnTests.cpp Unit
 	CSTR-Residual.cpp CSTR-Simulation.cpp
 	ConvectionDispersionOperator.cpp
 	CellKernelTests.cpp
-	BindingModelTests.cpp BindingModels.cpp
+	BindingModelTests.cpp BindingModels.cpp BindingModelAutoJacobian.cpp
 	ReactionModelTests.cpp ReactionModels.cpp
 	ParamDepTests.cpp ParameterDependencies.cpp
 	ModelSystem.cpp

--- a/test/Dummies.hpp
+++ b/test/Dummies.hpp
@@ -12,6 +12,7 @@
 
 #include "cadet/Model.hpp"
 #include "cadet/ParameterId.hpp"
+#include "cadet/ParameterProvider.hpp"
 
 #include "ConfigurationHelper.hpp"
 
@@ -62,4 +63,31 @@ namespace
 #endif
 	};
 
+	class DummyParameterProvider : public cadet::IParameterProvider
+	{
+	public:
+
+		DummyParameterProvider() { }
+		virtual ~DummyParameterProvider() CADET_NOEXCEPT { }
+
+		virtual double getDouble(const std::string& paramName) { return 0.0; }
+		virtual int getInt(const std::string& paramName) { return 0; }
+		virtual uint64_t getUint64(const std::string& paramName) { return 0; }
+		virtual bool getBool(const std::string& paramName) { return false; }
+		virtual std::string getString(const std::string& paramName) { return ""; }
+
+		virtual std::vector<double> getDoubleArray(const std::string& paramName) { return std::vector<double>(); }
+		virtual std::vector<int> getIntArray(const std::string& paramName) { return std::vector<int>(); }
+		virtual std::vector<uint64_t> getUint64Array(const std::string& paramName) { return std::vector<uint64_t>(); }
+		virtual std::vector<bool> getBoolArray(const std::string& paramName) { return std::vector<bool>(); }
+		virtual std::vector<std::string> getStringArray(const std::string& paramName) { return std::vector<std::string>(); }
+
+		virtual bool exists(const std::string& paramName) { return false; }
+		virtual bool isArray(const std::string& paramName) { return false; }
+
+		virtual std::size_t numElements(const std::string& paramName) { return 0; }
+
+		virtual void pushScope(const std::string& scope) { }
+		virtual void popScope() { }
+	};
 }

--- a/test/JsonTestModels.hpp
+++ b/test/JsonTestModels.hpp
@@ -23,6 +23,7 @@
 cadet::JsonParameterProvider createColumnWithSMA(const std::string& uoType, const std::string& spatialScheme);
 cadet::JsonParameterProvider createColumnWithTwoCompLinearBinding(const std::string& uoType, const std::string& spatialScheme);
 cadet::JsonParameterProvider createColumnLinearBenchmark(bool dynamicBinding, bool nonBinding, const std::string& uoType, const std::string& spatialScheme);
+nlohmann::json createLWEJson(const std::string& uoType, const std::string& spatialMethod);
 cadet::JsonParameterProvider createLWE(const std::string& uoType, const std::string& spatialScheme);
 cadet::JsonParameterProvider createPulseInjectionColumn(const std::string& uoType, const std::string& spatialScheme, bool dynamicBinding);
 cadet::JsonParameterProvider createLinearBenchmark(bool dynamicBinding, bool nonBinding, const std::string& uoType, const std::string& spatialScheme);


### PR DESCRIPTION
Defaults to automatically computing the Jacobian of a binding model if it does not provide an analytical one. The implementsAnalyticJacobian() is changed to a protected function that binding model implementations need to implement. This determines whether AD will be used to compute the Jacobian.

Closes #122.