### PR TITLE
Add CLA and CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,66 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The below token has repo scope for the project configured further below to store signatures.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CADET_CLA_SIGNATURES }}
+          PATH_TO_CLA: 'https://github.com/modsim/CADET/blob/main/CLA.md'
+        with:
+          path-to-signatures: 'signatures/version1/signatures.json'
+          path-to-document: $PATH_TO_CLA
+          # branch should not be protected
+          branch: 'main'
+          allowlist: dependabot[bot]
+
+          # the followings are the optional inputs - If the optional inputs are not given, then default values will be taken
+          # 👇 the remote organization and repo where the signatures should be stored
+          remote-organization-name: cadet
+          remote-repository-name: cla-signatures
+          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
+          #signed-commit-message: 'For example: $contributorName has signed the CLA in $owner/$repo#$pullRequestNo'
+          custom-notsigned-prcomment: |
+              Thank you for your submission, we really appreciate it!
+
+              Like many open-source projects we ask that you sign our [Contributor License Agreement](${{ env.PATH_TO_CLA }}) before we can accept your contribution.
+              To sign, please post two separate comments based on the following templates 👇
+
+              1. Comment:
+
+              ----
+              ```markdown
+              - [ ] The CADET maintainers know my real name.
+
+              At least one of the following two applies:
+
+              - [ ] The CADET maintainers know my current employer.
+
+              - [ ] I am *not* making this contribution on behalf of my current employer.
+              ```
+
+              ----
+
+              2. Comment:
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA.
+          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          # 👇 prevent contributors from revoking signatures after the merge (this is also the default)
+          lock-pullrequest-aftermerge: true
+          #use-dco-flag: true - If you are using DCO instead of CLA

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,66 @@
+# `CADET` CLA
+
+Thank you for your interest in contributing to Forschungszentrum Jülich GmbH - Institute for Bio- and Geosciences: IBG-1's `CADET` project ("We" or "Us").
+
+The purpose of this contributor agreement is to clarify and document the rights granted by contributors to Us.
+To make this document effective, please follow the instructions below.
+
+# How to use this CLA
+
+If You are an employee and have created the Contribution as part of your employment, You need to have Your employers approval as a Legal Entity.
+If You do not own the Copyright in the entire work of authorship, any other author of the Contribution must also sign this.
+
+# Definitions
+
+**"You"** means the individual Copyright owner who Submits a Contribution to Us.
+
+**"Legal Entity"** means an entity that is not a natural person.
+
+**"Contribution"** means any original work of authorship, including any original modifications or additions to an existing work of authorship, Submitted by You to Us, in which You own the Copyright.
+
+**"Copyright"** means all rights protecting works of authorship, including copyright, moral and neighboring rights, as appropriate, for the full term of their existence.
+
+**"Material"** means the software or documentation made available by Us to third parties.
+When this Agreement covers more than one software project, the Material means the software or documentation to which the Contribution was Submitted.
+After You Submit the Contribution, it may be included in the Material.
+
+**"Submit"** means any act by which a Contribution is transferred to Us by You by means of tangible or intangible media, including but not limited to electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Us, but excluding any transfer that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+**"Documentation"** means any non-software portion of a Contribution.
+
+# Rights and Obligations
+
+You hereby grant to Us a worldwide, royalty-free, non-exclusive, perpetual and irrevocable license, with the right to transfer an unlimited number of licenses or to grant sublicenses to third parties, under the Copyright covering the Contribution to use the Contribution by all means.
+
+We agree to (sub)license the Contribution or any Materials containing it, based on or derived from your Contribution non-exclusively under the terms of any licenses the Free Software Foundation classifies as Free Software License and which are approved by the Open Source Initiative as Open Source licenses.
+
+# Copyright
+
+You warrant, that you are legitimated to license the Contribution to us.
+
+# Acceptance of the CLA
+
+By submitting your Contribution via the [Repository](https://github.com/modsim/CADET) you accept this agreement.
+
+
+# Liability
+
+Except in cases of willful misconduct or physical damage directly caused to natural persons, the Parties will not be liable for any direct or indirect, material or moral, damages of any kind, arising out of the Licence or of the use of the Material, including, without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, loss of data or any commercial damage.
+However, the Licensor will be liable under statutory product liability laws as far such laws apply to the Material.
+
+# Warranty
+
+The Material is a work in progress, which is continuously being improved by numerous Contributors.
+It is not a finished work and may therefore contain defects or "bugs" inherent to this type of development.
+
+For the above reason, the Material is provided on an "as is" basis and without warranties of any kind concerning the Material, including without limitation,
+merchantability, fitness for a particular purpose, absence of defects or errors, accuracy, non-infringement of intellectual property rights other than copyright.
+
+# Miscellaneous
+
+This Agreement and all disputes, claims, actions, suits or other proceedings arising out of this agreement or relating in any way to it shall be governed by the laws of Germany excluding its private international law provisions.
+
+If any provision of this Agreement is found void and unenforceable, such provision will be replaced to the extent possible with a provision that comes closest to the meaning of the original provision and that is enforceable.
+The terms and conditions set forth in this Agreement shall apply notwithstanding any failure of essential purpose of this Agreement or any limited remedy to the maximum extent possible under law.
+
+You agree to notify Us of any facts or circumstances of which You become aware that would make this Agreement inaccurate in any respect.


### PR DESCRIPTION
Other steps taken (Formulation taken from Michael Ostheges summary)
- Created https://github.com/cadet/cla-signatures (private) for storing CLA signatures
- Created a fine-grained personal access token to be used by the GH Action for writing the signatures into the private repo
  
  - Under https://github.com/settings/personal-access-tokens/new
  - Token name CADET_CLA_SIGNATURES
  - Expiration 2025-06-23 (maximum is 1 year)
  - Resource owner `cadet`👈 This filters which repositories are available in the dropdown below!
  - Select repository: cadet/CLA-signatures
  - Permissions on Content must be set to Read & Write.
  - Added it as a secret CADET_CLA_SIGNATURES in the `modsim/cadet` project